### PR TITLE
fix f-string escape

### DIFF
--- a/src/onthespot/gui/mainui.py
+++ b/src/onthespot/gui/mainui.py
@@ -621,7 +621,7 @@ class MainWindow(QMainWindow):
 
             btn.setMinimumHeight(30)
             service = QTableWidgetItem(result['item_service'].title())
-            service.setIcon(QIcon(os.path.join(config.app_root, 'resources', 'icons', f'{result['item_service']}.png')))
+            service.setIcon(QIcon(os.path.join(config.app_root, 'resources', 'icons', f'{result["item_service"]}.png')))
 
             rows = self.tbl_search_results.rowCount()
             self.tbl_search_results.insertRow(rows)


### PR DESCRIPTION
Typo that prevents the program from running.

```
Traceback (most recent call last):
  [...] in <module>
    from .gui.mainui import MainWindow
  File "[...]/site-packages/onthespot/gui/mainui.py", line 624
    service.setIcon(QIcon(os.path.join(config.app_root, 'resources', 'icons', f'{result['item_service']}.png')))
                                                                                         ^^^^^^^^^^^^
SyntaxError: f-string: unmatched '['
```