### PR TITLE
Memory decorator for troubleshooting.

### DIFF
--- a/src/onthespot/runtimedata.py
+++ b/src/onthespot/runtimedata.py
@@ -1,5 +1,8 @@
 import sys
 import os
+import tracemalloc
+from functools import wraps
+import linecache
 import logging
 import threading
 from logging.handlers import RotatingFileHandler
@@ -47,3 +50,46 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 sys.excepthook = handle_exception
+
+def log_function_memory(func):
+    tracemalloc.start()
+    top_limit = 10
+    def display_top(snapshot, snapshot_log_prefix, key_type='lineno'):
+        snapshot = snapshot.filter_traces((
+            tracemalloc.Filter(False, "<frozen importlib._bootstrap>"),
+            tracemalloc.Filter(False, "<unknown>"),
+        ))
+        top_stats = snapshot.statistics(key_type)
+
+        logger_.debug(f"{snapshot_log_prefix} Top {top_limit} lines")
+        for index, stat in enumerate(top_stats[:top_limit], 1):
+            frame = stat.traceback[0]
+            logger_.debug("#%s: %s:%s: %.1f KiB"
+                % (index, frame.filename, frame.lineno, stat.size / 1024))
+            line = linecache.getline(frame.filename, frame.lineno).strip()
+            if line:
+                logger_.debug(f"{snapshot_log_prefix} -- {line}"  )
+
+        other = top_stats[top_limit:]
+        if other:
+            size = sum(stat.size for stat in other)
+            logger_.debug("%s other: %.1f KiB" % (len(other), size / 1024))
+        total = sum(stat.size for stat in top_stats)
+        logger_.debug("Total allocated size: %.1f KiB" % (total / 1024))
+
+    @wraps(func)
+    def snapshot_function_call(*args, **kwargs):
+        prefix = f"FuncMem-{func.__name__}: "
+        before_func = tracemalloc.take_snapshot()
+        logger_.debug(f"Snapshotting before {func.__name__} call")
+        ret_val = func(*args, **kwargs)
+        display_top(before_func, prefix)
+        logger_.debug(f"Snapshotting before {func.__name__} call")
+        after_func = tracemalloc.take_snapshot()
+        display_top(after_func, prefix)
+        top_stats = after_func.compare_to(before_func, 'lineno')
+        logger_.debug(f"{prefix} Top {top_limit} differences")
+        for stat in top_stats[:10]:
+            logger_.debug(f"{prefix}{stat}")
+        return ret_val
+    return snapshot_function_call

--- a/src/onthespot/runtimedata.py
+++ b/src/onthespot/runtimedata.py
@@ -79,12 +79,12 @@ def log_function_memory(func):
 
     @wraps(func)
     def snapshot_function_call(*args, **kwargs):
-        prefix = f"FuncMem-{func.__name__}: "
+        prefix = f"{func.__name__}: "
         before_func = tracemalloc.take_snapshot()
         logger_.debug(f"Snapshotting before {func.__name__} call")
         ret_val = func(*args, **kwargs)
         display_top(before_func, prefix)
-        logger_.debug(f"Snapshotting before {func.__name__} call")
+        logger_.debug(f"Snapshotting after {func.__name__} call")
         after_func = tracemalloc.take_snapshot()
         display_top(after_func, prefix)
         top_stats = after_func.compare_to(before_func, 'lineno')

--- a/src/onthespot/runtimedata.py
+++ b/src/onthespot/runtimedata.py
@@ -77,14 +77,14 @@ def log_function_memory(func):
         total = sum(stat.size for stat in top_stats)
         logger_.debug("Total allocated size: %.1f KiB" % (total / 1024))
 
-    @wraps(func)
+    @wraps(wrap_func)
     def snapshot_function_call(*args, **kwargs):
-        prefix = f"{func.__name__}: "
+        prefix = f"{wrap_func.__name__}: "
         before_func = tracemalloc.take_snapshot()
-        logger_.debug(f"Snapshotting before {func.__name__} call")
-        ret_val = func(*args, **kwargs)
+        logger_.debug(f"Snapshotting before {wrap_func.__name__} call")
+        ret_val = wrap_func(*args, **kwargs)
         display_top(before_func, prefix)
-        logger_.debug(f"Snapshotting after {func.__name__} call")
+        logger_.debug(f"Snapshotting after {wrap_func.__name__} call")
         after_func = tracemalloc.take_snapshot()
         display_top(after_func, prefix)
         top_stats = after_func.compare_to(before_func, 'lineno')


### PR DESCRIPTION
Adds helper function to track memory usage of a given function. Usage looks something like 
```
@log_function_memory
    def fill_search_table(self):
```
When put into debug mode will yield logs like 

```
[2024-11-01 12:27:39,187 :: gui.main_ui :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/gui/mainui.py -> 284:  fill_account_table() :: INFO] -> Accounts table was populated !
[2024-11-01 12:27:46,845 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 85:snapshot_function_call() :: DEBUG] -> Snapshotting before fill_search_table call
[2024-11-01 12:27:46,845 :: spotify.api :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/search.py -> 36:  get_search_results() :: INFO] -> Search clicked with value term mount salem
[2024-11-01 12:27:46,882 :: spotify.api :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/api/spotify.py -> 396:spotify_get_search_results() :: INFO] -> Get search result for term 'mount salem'
[2024-11-01 12:27:48,992 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 65:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  Top 10 lines
[2024-11-01 12:27:48,992 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #1: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:562: 282.2 KiB
[2024-11-01 12:27:48,996 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_class = super().__new__(metacls, cls, bases, classdict, **kwds)
[2024-11-01 12:27:48,996 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #2: /nix/store/6xwn16idskfqby2kmvz18qks8kylskjn-python3.11-pyqt6-6.7.0.dev2404081550/lib/python3.11/site-packages/PyQt6/uic/Loader/qobjectcreator.py:145: 264.0 K
iB
[2024-11-01 12:27:48,997 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- return ctor(*ctor_args, **ctor_kwargs)
[2024-11-01 12:27:48,997 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #3: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:257: 210.6 KiB
[2024-11-01 12:27:48,997 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_member = enum_class._new_member_(enum_class)
[2024-11-01 12:27:48,997 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #4: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:265: 183.4 KiB
[2024-11-01 12:27:48,997 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_member._value_ = enum_class._member_type_(*args)
[2024-11-01 12:27:48,998 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #5: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:839: 146.6 KiB
[2024-11-01 12:27:48,998 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- super().__setattr__(name, value)
[2024-11-01 12:27:48,998 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #6: /nix/store/6xwn16idskfqby2kmvz18qks8kylskjn-python3.11-pyqt6-6.7.0.dev2404081550/lib/python3.11/site-packages/PyQt6/uic/properties.py:127: 106.2 KiB
[2024-11-01 12:27:48,999 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- scope = getattr(scope, tail)
[2024-11-01 12:27:48,999 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #7: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:347: 77.9 KiB
[2024-11-01 12:27:48,999 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_class._value2member_map_.setdefault(value, enum_member)
[2024-11-01 12:27:48,999 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #8: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:259: 58.0 KiB
[2024-11-01 12:27:48,999 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_member = enum_class._new_member_(enum_class, *args)
[2024-11-01 12:27:49,000 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #9: <frozen importlib._bootstrap_external>:729: 52.5 KiB
[2024-11-01 12:27:49,000 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 68:         display_top() :: DEBUG] -> #10: /nix/store/h723hb9m43lybmvfxkk6n7j4v664qy7b-python3-3.11.9/lib/python3.11/enum.py:342: 47.2 KiB
[2024-11-01 12:27:49,000 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 72:         display_top() :: DEBUG] -> FuncMem-fill_search_table:  -- enum_class._member_map_[member_name] = enum_member
[2024-11-01 12:27:49,000 :: runtimedata :: /home/tyler/Music/OnTheSpot/onthespot/src/onthespot/runtimedata.py -> 77:         display_top() :: DEBUG] -> 467 other: 500.1 KiB
```