### PR TITLE
Fixed cover art for Tidal

### DIFF
--- a/src/onthespot/api/tidal.py
+++ b/src/onthespot/api/tidal.py
@@ -253,7 +253,7 @@ def tidal_get_track_metadata(token, item_id):
     info['total_discs'] = album_data.get('data', {}).get('attributes', {}).get('numberOfVolumes')
     info['release_year'] = album_data.get('data', {}).get('attributes', {}).get('releaseDate').split("-")[0]
     info['upc'] = album_data.get('data', {}).get('attributes', {}).get('barcodeId')
-    info['image_url'] = album_data.get('data', {}).get('attributes', {}).get('imageLinks', {})[0].get('href')
+    info['image_url'] = tidal_get_album_cover(token=token, album_id=track_data['album']['id'])
     info['album_type'] = album_data.get('data', {}).get('attributes', {}).get('type').lower()
     info['is_playable'] = track_data.get('streamReady')
 
@@ -422,3 +422,24 @@ def tidal_get_mix_data(token, mix_id):
     for track in mix_data['rows'][1]['modules'][0]['pagedList']['items']:
         track_ids.append(track['id'])
     return playlist_name, playlist_by, track_ids
+
+def tidal_get_album_cover(token, album_id):
+    logger.info(f"Get cover for album: {album_id}")
+    headers = {}
+    headers["Authorization"] = f"Bearer {token['access_token']}"
+    params = {}
+    params["countryCode"] = token['country_code']
+
+    try:
+        cover_art_data = make_call(f"{BASEV2_URL}/albums/{album_id}/relationships/coverArt", headers=headers, params=params)
+        cover_id = cover_art_data.get('data', {})[0].get('id')
+
+        cover_art_link = make_call(f"{BASEV2_URL}/artworks/{cover_id}", headers=headers, params=params)
+        cover_art = cover_art_link.get('data', {}).get('attributes', {}).get('files', {})[0].get('href')
+
+        return cover_art
+    
+    except:
+        logger.error(f"Cover not found for album: {album_id}")
+        return None
+


### PR DESCRIPTION
After some change on the Tidal API it's now needed to get on another endpoint the ID for the artwork and then it is possible to get the link as before. The Tidal API document site isn't update with this change but I found Tidal's Swagger and it has these changes.

Also, now if something happens with the cover art endpoint or something like it, the download won't break and it will continue without a cover art.

Related to https://github.com/justin025/onthespot/issues/163