### PR TITLE
Suggestion: onthespot.cli should return code 1 when using `--download` and the track download fails

### DIFF
--- a/src/onthespot/cli.py
+++ b/src/onthespot/cli.py
@@ -115,6 +115,7 @@ def main():
         mirrorplayback.start()
 
     if args.download:
+        failed_download = False
         print(f"\033[32mParsing URL: {args.download}\033[0m")
         parse_url(args.download)
         while not download_queue:
@@ -126,9 +127,14 @@ def main():
             for item in download_queue.values():
                 if item['item_status'] in ('Unavailable', 'Failed'):
                     print(f"\033[31mItem ID {item['item_id']} {item['item_status']}'\033[0m")
+                    failed_download = True
 
-        print("\033[32mDownload Completed. Exiting...\033[0m")
-        os._exit(0)
+        if failed_download:
+            print("\033[31mAt least one track download failed. Exiting with failure...\033[0m")
+            os._exit(1)
+        else:
+            print("\033[32mDownload Completed. Exiting...\033[0m")
+            os._exit(0)
 
     CLI().cmdloop()
 


### PR DESCRIPTION
When integrating OnTheSpot into an automation script, the current behaviour makes it difficult to automate error checking, as the script never exits with return code 1 unless an unhandled error occurs.

I have attached an image to show the differences between current behaviour and my patch.

<img width="582" height="454" alt="final" src="https://github.com/user-attachments/assets/3e860b1f-6bb9-488c-b985-306a48fbe00f" />
