### PR TITLE
Docker: run on ARM without emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,42 @@
-FROM debian:latest
-ENV DEBIAN_FRONTEND=noninteractive
+FROM python:3-slim AS base
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/venv/bin:$PATH"
+
 SHELL ["/bin/bash", "-c"]
-RUN apt update -y
-RUN apt upgrade -y
-RUN apt install -y python3 python3-pip python3.11-venv ffmpeg git libegl1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libegl1 \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
+FROM base AS builder
+
 RUN python3 -m venv venv
-RUN source /app/venv/bin/activate
-RUN /app/venv/bin/python3 -m pip install git+https://github.com/justin025/onthespot
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install --no-cache-dir --prefer-binary -r requirements.txt
+
+COPY pyproject.toml setup.cfg ./
+COPY src ./src
+RUN pip install --no-cache-dir .
+
+# Cleanup: remove caches, tests, and strip shared objects
+RUN find /app/venv \
+    \( -type d -name "__pycache__" -o -type d -name "tests" -o -type d -name "test" \) \
+    -exec rm -rf {} + \
+    && find /app/venv -type f -name '*.pyc' -delete \
+    && find /app/venv/lib -type f -name '*.so' -exec strip --strip-unneeded {} + || true
+
+
+FROM base AS runtime
+
+COPY --from=builder /app/venv /app/venv
+
 EXPOSE 5000
-CMD ["/app/venv/bin/onthespot-web", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["onthespot-web", "--host", "0.0.0.0", "--port", "5000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ffmpeg \
     libegl1 \
-    git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 FROM base AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv venv
 COPY requirements.txt .


### PR DESCRIPTION
I wanted to install the web version on my pi, but i noticed that the docker image would not build on arm except with emulation. As emulation is extremely slow i investigated why it would fail and found the issue.
The pyqt dependency could not be installed with pip.
As a workaround pyqt is now installed with apt and then copied into the venv.
The pyqt version installed by apt is 6.4.2 so i downgraded the dependency, but still everything works as expected.

Maybe someone with a deeper understanding of the python and pip ecosystem can improve this, but it works pretty great so far with this docker image.
