### PR TITLE
Optimize Dockerfile for Build Performance and Smaller Production Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM debian:latest
-ENV DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-c"]
-RUN apt update -y
-RUN apt upgrade -y
-RUN apt install -y python3 python3-pip python3.11-venv ffmpeg git libegl1
-WORKDIR /app
-RUN python3 -m venv venv
-RUN source /app/venv/bin/activate
-RUN /app/venv/bin/python3 -m pip install git+https://github.com/justin025/onthespot
+FROM python:3.11-slim-bookworm AS base
+
+FROM base AS updated-system
+
+RUN apt-get update && \
+    apt-get install -y ffmpeg git libegl1
+
+RUN pip install git+https://github.com/justin025/onthespot
+
+FROM updated-system AS cleaned-system
+
+RUN apt-get purge -y git && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /root/.cache
+
+FROM cleaned-system AS prod
 EXPOSE 5000
-CMD ["/app/venv/bin/onthespot-web", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["onthespot-web", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION
This PR refactors the Dockerfile to utilize a multi-stage build process, improving both build speed and final image size.
Key changes include:

- Use multi-stage build for efficient caching and minimal production image.
- Install apt and pip dependencies in intermediate stages, keeping caches for faster rebuilds.
- Remove unnecessary build dependencies (git) and all cache data in the cleaned-system stage.
- Expose only runtime requirements in the final prod image.
- General code cleanup and best practices applied.

These changes result in a more maintainable Dockerfile, faster rebuilds during development, and a leaner image for production deployment.