### PR TITLE
Serialize web queue with a consistent order

### DIFF
--- a/src/onthespot/web.py
+++ b/src/onthespot/web.py
@@ -237,7 +237,7 @@ def restart():
 @login_required
 def get_items():
     with download_queue_lock:
-        return Response(json.dumps(download_queue), mimetype='application/json')
+        return Response(json.dumps(download_queue, sort_keys=True), mimetype='application/json')
 
 @app.route('/api/cancel/<path:local_id>', methods=['POST'])
 @login_required


### PR DESCRIPTION
Orders the donwload_queue on the web by key.
This way the order will not be randomized every second.
Fixes #202 

As a future feature it might be nice to be able to sort the download_queue by clicking on the headers eg. by name / status / progress?