### PR TITLE
Fix Spotify token expire and playback mirroring playlist error

### DIFF
--- a/src/onthespot/accounts.py
+++ b/src/onthespot/accounts.py
@@ -49,12 +49,12 @@ class FillAccountPool(QThread):
         self.finished.emit()
 
 
-def get_account_token(item_service, rotate=False):
+def get_account_token(item_service, rotate=False, reinit = False):
     if item_service in ('bandcamp', 'youtube_music', 'generic'):
         return
     parsing_index = config.get('active_account_number')
     if item_service == account_pool[parsing_index]['service'] and not rotate:
-        return globals()[f"{item_service}_get_token"](parsing_index)
+        return globals()[f"{item_service}_get_token"](parsing_index, reinit)
     else:
         for i in range(parsing_index + 1, parsing_index + len(account_pool) + 1):
             index = i % len(account_pool)

--- a/src/onthespot/accounts.py
+++ b/src/onthespot/accounts.py
@@ -49,12 +49,12 @@ class FillAccountPool(QThread):
         self.finished.emit()
 
 
-def get_account_token(item_service, rotate=False, reinit = False):
+def get_account_token(item_service, rotate=False):
     if item_service in ('bandcamp', 'youtube_music', 'generic'):
         return
     parsing_index = config.get('active_account_number')
     if item_service == account_pool[parsing_index]['service'] and not rotate:
-        return globals()[f"{item_service}_get_token"](parsing_index, reinit)
+        return globals()[f"{item_service}_get_token"](parsing_index)
     else:
         for i in range(parsing_index + 1, parsing_index + len(account_pool) + 1):
             index = i % len(account_pool)

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -70,7 +70,7 @@ class MirrorSpotifyPlayback(QObject):
                                 else:
                                     continue
                                 token = get_account_token('spotify')
-                                playlist_name, playlist_by = spotify_get_playlist_data(token.get("user-read-email"), playlist_id)
+                                playlist_name, playlist_by = spotify_get_playlist_data(token, playlist_id)
                                 parent_category = 'playlist'
                             elif data['context'].get('type') == 'collection':
                                 playlist_name = 'Liked Songs'

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -23,7 +23,6 @@ class MirrorSpotifyPlayback(QObject):
         super().__init__()
         self.thread = None
         self.is_running = False
-        self.reinit = False
 
     def start(self):
         if self.thread is None:
@@ -49,7 +48,7 @@ class MirrorSpotifyPlayback(QObject):
         while self.is_running:
             time.sleep(5)
             try:
-                token = get_account_token('spotify', self.reinit).tokens()
+                token = get_account_token('spotify').tokens()
             except (AttributeError, IndexError):
                 # Account pool hasn't been filled yet
                 continue
@@ -58,7 +57,9 @@ class MirrorSpotifyPlayback(QObject):
                 resp = requests.get(url, headers={"Authorization": f"Bearer {token.get('user-read-currently-playing')}"})
             except:
                 logger.info("Session Expired, reinitializing...")
-                self.reinit = True
+                parsing_index = config.get('active_account_number')
+                spotify_re_init_session(account_pool[parsing_index])
+                token = account_pool[parsing_index]['login']['session']
                 continue
             if resp.status_code == 200:
                 data = resp.json()
@@ -240,17 +241,13 @@ def spotify_re_init_session(account):
         logger.error('Failed to re init session !')
 
 
-def spotify_get_token(parsing_index, reinit):
-    if reinit:
+def spotify_get_token(parsing_index):
+    try:
+        token = account_pool[parsing_index]['login']['session']
+    except (OSError, AttributeError):
+        logger.info(f'Failed to retreive token for {account_pool[parsing_index]["username"]}, attempting to reinit session.')
         spotify_re_init_session(account_pool[parsing_index])
         token = account_pool[parsing_index]['login']['session']
-    else:
-        try:
-            token = account_pool[parsing_index]['login']['session']
-        except (OSError, AttributeError):
-            logger.info(f'Failed to retreive token for {account_pool[parsing_index]["username"]}, attempting to reinit session.')
-            spotify_re_init_session(account_pool[parsing_index])
-            token = account_pool[parsing_index]['login']['session']
     return token
 
 


### PR DESCRIPTION
Hi,

This PR fixes #211 and #222  

I've just added a try, except on the request to catch the expiration error and reinitialize the session
And fixed the parameter passed to the function for getting the playlist data in the mirroring service

I've tested in Windows for ~2hr and it works fine, but I'm only using spotify.