### PR TITLE
feat: Build ffmpeg for native macOs Apple silicon

### DIFF
--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -1,49 +1,11 @@
 name: Release Builder
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
   release:
     types: [published]
 
 jobs:
-  windows-x86_64-build:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-
-      - name: Run Windows Build Script
-        run: scripts\build_windows.bat
-        shell: cmd
-
-      - name: Upload Windows Executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: OnTheSpot-x86_64.exe
-          path: dist/OnTheSpot.exe
-
-      - name: Upload to Release (Windows)
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/OnTheSpot.exe
-          asset_name: OnTheSpot-x86_64.exe
-          asset_content_type: application/octet-stream
-
-  macos-x86_64-build:
+  macos-build:
     runs-on: macos-15-intel
     steps:
       - name: Checkout Repository
@@ -71,7 +33,7 @@ jobs:
           asset_content_type: application/x-apple-diskimage
 
   macos-arm64-build:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -96,67 +58,3 @@ jobs:
           asset_path: dist/OnTheSpot.dmg
           asset_name: OnTheSpot-arm64.dmg
           asset_content_type: application/x-apple-diskimage
-
-  linux-x86_64-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y patchelf fuse libfuse2 wget
-
-      - name: Run Linux Build Script
-        run: scripts/build_linux.sh
-        shell: bash
-
-      - name: Upload Linux Executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: OnTheSpot-x86_64.tar.gz
-          path: dist/OnTheSpot.tar.gz
-
-      - name: Upload to Release (Linux)
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/OnTheSpot.tar.gz
-          asset_name: OnTheSpot-x86_64.tar.gz
-          asset_content_type: application/gzip
-
-  appimage-x86_64-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgssapi-krb5-2 libxcb-cursor0 libxcb-xinerama0 libxcb1 ffmpeg desktop-file-utils fuse patchelf wget
-
-      - name: Run AppImage Build Script
-        run: scripts/build_appimage.sh
-        shell: bash
-
-      - name: Upload AppImage Executable
-        uses: actions/upload-artifact@v4
-        with:
-          name: OnTheSpot-x86_64.AppImage
-          path: dist/OnTheSpot-x86_64.AppImage
-
-      - name: Upload to Release (AppImage)
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/OnTheSpot-x86_64.AppImage
-          asset_name: OnTheSpot-x86_64.AppImage
-          asset_content_type: application/octet-stream

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -3,9 +3,42 @@ name: Release Builder
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
-  macos-build:
+  windows-x86_64-build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Run Windows Build Script
+        run: scripts\build_windows.bat
+        shell: cmd
+
+      - name: Upload Windows Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.exe
+          path: dist/OnTheSpot.exe
+
+      - name: Upload to Release (Windows)
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.exe
+          asset_name: OnTheSpot-x86_64.exe
+          asset_content_type: application/octet-stream
+
+  macos-x86_64-build:
     runs-on: macos-15-intel
     steps:
       - name: Checkout Repository
@@ -58,3 +91,67 @@ jobs:
           asset_path: dist/OnTheSpot.dmg
           asset_name: OnTheSpot-arm64.dmg
           asset_content_type: application/x-apple-diskimage
+
+  linux-x86_64-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf fuse libfuse2 wget
+
+      - name: Run Linux Build Script
+        run: scripts/build_linux.sh
+        shell: bash
+
+      - name: Upload Linux Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.tar.gz
+          path: dist/OnTheSpot.tar.gz
+
+      - name: Upload to Release (Linux)
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.tar.gz
+          asset_name: OnTheSpot-x86_64.tar.gz
+          asset_content_type: application/gzip
+
+  appimage-x86_64-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgssapi-krb5-2 libxcb-cursor0 libxcb-xinerama0 libxcb1 ffmpeg desktop-file-utils fuse patchelf wget
+
+      - name: Run AppImage Build Script
+        run: scripts/build_appimage.sh
+        shell: bash
+
+      - name: Upload AppImage Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.AppImage
+          path: dist/OnTheSpot-x86_64.AppImage
+
+      - name: Upload to Release (AppImage)
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot-x86_64.AppImage
+          asset_name: OnTheSpot-x86_64.AppImage
+          asset_content_type: application/octet-stream

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -38,7 +38,7 @@ else
     cd builder/ffmpeg-build-script-master
     ./build-ffmpeg --build --skip-install
     
-    cp /workspace/bin/ffmpeg ../../dist/ffmpeg
+    cp workspace/bin/ffmpeg ../../dist/ffmpeg
 
     cd ../..
 fi

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -19,24 +19,16 @@ venv/bin/pip install -r requirements.txt
 
 echo " => Build FFMPEG (Optional)"
 
-FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
-if ! [ -f "dist/ffmpeg" ]; then
-	curl -L -o build/ffmpeg.zip https://github.com/markus-perl/ffmpeg-build-script/archive/refs/heads/master.zip
-    unzip build/ffmpeg.zip -d builder
-	cd builder/ffmpeg-build-script
-	./build-ffmpeg --build
+curl -L -o build/ffmpeg.zip https://github.com/markus-perl/ffmpeg-build-script/archive/refs/heads/master.zip
+unzip build/ffmpeg.zip -d builder
+cd builder/ffmpeg-build-script-master
+./build-ffmpeg --build --skip-install
 
-	mv app/workspace/bin/ffmpeg dist/ffmpeg
-	
-#    cd build
-#    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz
-#    tar xf ffmpeg.tar.xz
-#    cd ffmpeg-*
-#    ./configure --enable-small --disable-ffplay --disable-ffprobe --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages
-#    make
-#    cp ffmpeg ../../dist
-#    cd ../..
-fi
+mv app/workspace/bin/ffmpeg ../../dist/ffmpeg
+
+FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
+
+
 
 echo " => Running PyInstaller to create .app package..."
 pyinstaller --windowed \

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -7,6 +7,7 @@ echo " => Cleaning up previous builds and preparing the environment..."
 rm -f ./dist/OnTheSpot.tar.gz
 mkdir build
 mkdir dist
+mkdir builder
 python3 -m venv venv
 source ./venv/bin/activate
 
@@ -20,8 +21,13 @@ echo " => Build FFMPEG (Optional)"
 
 FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
 if ! [ -f "dist/ffmpeg" ]; then
-	bash <(curl -s "https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1")
-	mv ffmpeg-build/app/workspace/bin/ffmpeg dist/ffmpeg
+	curl -L -o build/ffmpeg.zip https://github.com/markus-perl/ffmpeg-build-script/archive/refs/heads/master.zip
+    unzip build/ffmpeg.zip -d builder
+	cd builder/ffmpeg-build-script
+	./build-ffmpeg --build
+
+	mv app/workspace/bin/ffmpeg dist/ffmpeg
+	
 #    cd build
 #    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz
 #    tar xf ffmpeg.tar.xz

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -38,7 +38,7 @@ else
     cd builder/ffmpeg-build-script-master
     ./build-ffmpeg --build --skip-install
     
-    cp app/workspace/bin/ffmpeg ../../dist/ffmpeg
+    cp /workspace/bin/ffmpeg ../../dist/ffmpeg
 
     cd ../..
 fi

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -20,7 +20,7 @@ echo " => Build FFMPEG (Optional)"
 
 FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
 if ! [ -f "dist/ffmpeg" ]; then
-	curl -s https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1
+	bash <(curl -s "https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1")
 	mv ffmpeg-build/app/workspace/bin/ffmpeg dist/ffmpeg
 #    cd build
 #    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -17,23 +17,19 @@ venv/bin/pip install -r requirements.txt
 
 
 echo " => Build FFMPEG (Optional)"
-# Only building with ffmpeg binary for x86_64 macs, this
-# script will likely need to be revised to compile ffmpeg
-# from src to support both.
-if uname -m | grep -q x86_64; then
-	FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
-	if ! [ -f "dist/ffmpeg" ]; then
-    	curl -L -o build/ffmpeg.zip https://evermeet.cx/ffmpeg/ffmpeg-7.1.zip
-    	unzip build/ffmpeg.zip -d dist
-	#    cd build
-	#    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz
-	#    tar xf ffmpeg.tar.xz
-	#    cd ffmpeg-*
-	#    ./configure --enable-small --disable-ffplay --disable-ffprobe --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages
-	#    make
-	#    cp ffmpeg ../../dist
-	#    cd ../..
-	fi
+
+FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
+if ! [ -f "dist/ffmpeg" ]; then
+	curl -s https://raw.githubusercontent.com/markus-perl/ffmpeg-build-script/master/web-install.sh?v1
+	mv ffmpeg-build/app/workspace/bin/ffmpeg dist/ffmpeg
+#    cd build
+#    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz
+#    tar xf ffmpeg.tar.xz
+#    cd ffmpeg-*
+#    ./configure --enable-small --disable-ffplay --disable-ffprobe --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages
+#    make
+#    cp ffmpeg ../../dist
+#    cd ../..
 fi
 
 echo " => Running PyInstaller to create .app package..."

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -19,12 +19,30 @@ venv/bin/pip install -r requirements.txt
 
 echo " => Build FFMPEG (Optional)"
 
-curl -L -o build/ffmpeg.zip https://github.com/markus-perl/ffmpeg-build-script/archive/refs/heads/master.zip
-unzip build/ffmpeg.zip -d builder
-cd builder/ffmpeg-build-script-master
-./build-ffmpeg --build --skip-install
+if uname -m | grep -q x86_64; then
+	if ! [ -f "dist/ffmpeg" ]; then
+    	curl -L -o build/ffmpeg.zip https://evermeet.cx/ffmpeg/ffmpeg-7.1.zip
+    	unzip build/ffmpeg.zip -d dist
+	#    cd build
+	#    curl https://ffmpeg.org/releases/ffmpeg-7.1.1.tar.xz -o ffmpeg.tar.xz
+	#    tar xf ffmpeg.tar.xz
+	#    cd ffmpeg-*
+	#    ./configure --enable-small --disable-ffplay --disable-ffprobe --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages
+	#    make
+	#    cp ffmpeg ../../dist
+	#    cd ../..
+	fi
+else
+    curl -L -o build/ffmpeg.zip https://github.com/markus-perl/ffmpeg-build-script/archive/refs/heads/master.zip
+    unzip build/ffmpeg.zip -d builder
+    cd builder/ffmpeg-build-script-master
+    ./build-ffmpeg --build --skip-install
+    
+    cp app/workspace/bin/ffmpeg ../../dist/ffmpeg
 
-mv app/workspace/bin/ffmpeg ../../dist/ffmpeg
+    cd ../..
+fi
+
 
 FFBIN="--add-binary=dist/ffmpeg:onthespot/bin/ffmpeg"
 
@@ -74,7 +92,7 @@ hdiutil create -srcfolder dist/dmg -format UDZO -o dist/OnTheSpot.dmg
 
 
 echo " => Cleaning up temporary files..."
-rm -rf __pycache__ build venv *.spec
+rm -rf __pycache__ build builder venv *.spec
 
 
 echo " => Done! .dmg available in 'dist/OnTheSpot.dmg'."


### PR DESCRIPTION
This PR modifies the build script to build a custom ffmpeg for Apple Silicon.

closes #209 
closes #250 

this still needs to be checked as the version of ffmpeg that this builds is 8.0, and the convert_audio function seems to return a different value.