### PR TITLE
fix: update Vorbis Comment metadata for Ogg container files

### DIFF
--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -351,6 +351,8 @@ def embed_metadata(item, metadata):
             elif key in ['album_artists'] and config.get("embed_albumartist"):
                 if filetype == '.mp3':
                     command += ['-metadata', 'TPE2={}'.format(value)]
+                elif filetype in ['.flac', '.ogg', '.opus']:
+                    command += ['-metadata', 'albumartist={}'.format(value)]
                 else:
                     command += ['-metadata', 'album_artist={}'.format(value)]
 
@@ -363,11 +365,18 @@ def embed_metadata(item, metadata):
             elif key in ['discnumber', 'disc_number', 'disknumber', 'disk_number'] and config.get("embed_discnumber"):
                 if filetype == '.mp3':
                     command += ['-metadata', 'TPOS={}/{}'.format(value, metadata['total_discs'])]
+                elif filetype in ['.flac', '.ogg', '.opus']:
+                    command += ['-metadata', 'disc={}'.format(value)]
+                    command += ['-metadata', 'totaldisc={}'.format(metadata['total_discs'])]
                 else:
                     command += ['-metadata', 'disc={}/{}'.format(value, metadata['total_discs'])]
 
             elif key in ['track_number', 'tracknumber'] and config.get("embed_tracknumber"):
-                command += ['-metadata', 'track={}/{}'.format(value, metadata.get('total_tracks'))]
+                 if filetype in ['.flac', '.ogg', '.opus']:
+                    command += ['-metadata', 'track={}'.format(value)]
+                    command += ['-metadata', 'totaltrack={}'.format(metadata.get('total_tracks'))]
+                 else:
+                    command += ['-metadata', 'track={}/{}'.format(value, metadata.get('total_tracks'))]
 
             elif key == 'genre' and config.get("embed_genre"):
                 command += ['-metadata', 'genre={}'.format(value)]
@@ -393,6 +402,9 @@ def embed_metadata(item, metadata):
             elif key == 'label' and config.get("embed_label"):
                 if filetype == '.mp3':
                     command += ['-metadata', 'publisher={}'.format(value)]
+                elif filetype in ['.flac', '.ogg', '.opus']:
+                    command += ['-metadata', 'publisher={}'.format(value)]
+                    command += ['-metadata', 'label={}'.format(value)]
 
             elif key == 'copyright' and config.get("embed_copyright"):
                 command += ['-metadata', 'copyright={}'.format(value)]
@@ -401,6 +413,8 @@ def embed_metadata(item, metadata):
                 if filetype == '.mp3':
                     # Incorrectly embedded to TXXX:COMM, patch sent upstream
                     command += ['-metadata', 'COMM={}'.format(value)]
+                elif filetype in ['.flac', '.ogg', '.opus']:
+                    command += ['-metadata', 'description={}'.format(value)]
                 else:
                     command += ['-metadata', 'comment={}'.format(value)]
 


### PR DESCRIPTION
* Update album artist to use 'albumartist' tag for Vorbis Comment
* Update disc number to use 'disc' and 'totaldisc' tags for Vorbis Comment
* Update track number to use 'track' and 'totaltrack' tags for Vorbis Comment
* Add embed_label as publisher and label tags for Vorbis Comment
* Update description to use 'description' tag for Vorbis Comment

### References
- [Tag Mapping - Hydrogenaudio Knowledgebase](https://wiki.hydrogenaudio.org/index.php?title=Tag_Mapping)
- [jthink.net/jaudiotagger/tagmapping.html](http://www.jthink.net/jaudiotagger/tagmapping.html)
  - Jaudiotagger is the Audio Tagging library used by [Jaikoz](https://www.jthink.net/jaikoz/) and [SongKong](https://www.jthink.net/songkong) taggers for tagging data in Audio files. It currently fully supports **Mp3**, **Mp4** (Mp4 audio, M4a and M4p audio) **Ogg Vorbis**, **Flac**, **Wav**, **Aif**, **Dsf** and **Wma**
[Mapping of Properties to Various Formats (TagLib)](https://taglib.org/api/p_propertymapping.html)
- [TagLib](https://taglib.org) is a library for reading and editing the meta-data of several popular audio formats. Used by VLC,  Kodi
- [Appendix B: Tag Mapping — MusicBrainz Picard v2.13.3 documentation](https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html)
