### PR TITLE
#269 Proper Rate Limit Handling with Retry and Global Request Serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 .markdownlintignore
 .markdownlint.json
 .vscode
+
+# Mac OSX
+.DS_Store

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -536,11 +536,20 @@ def spotify_get_track_metadata(token, item_id):
     headers['Authorization'] = f"Bearer {token.tokens().get('user-read-email')}"
 
     track_data = make_call(f'{BASE_URL}/tracks?ids={item_id}&market=from_token', headers=headers)
+    time.sleep(config.get('api_request_delay', 0.1))
+
     album_data = make_call(f"{BASE_URL}/albums/{track_data.get('tracks', [])[0].get('album', {}).get('id')}", headers=headers)
+    time.sleep(config.get('api_request_delay', 0.1))
+
     artist_data = make_call(f"{BASE_URL}/artists/{track_data.get('tracks', [])[0].get('artists', [])[0].get('id')}", headers=headers)
+    time.sleep(config.get('api_request_delay', 0.1))
+
     album_track_ids = spotify_get_album_track_ids(token, track_data.get('tracks', [])[0].get('album', {}).get('id'))
+    time.sleep(config.get('api_request_delay', 0.1))
+
     try:
         track_audio_data = make_call(f'{BASE_URL}/audio-features/{item_id}', headers=headers)
+        time.sleep(config.get('api_request_delay', 0.1))
     except Exception:
         track_audio_data = ''
     try:

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -153,7 +153,10 @@ class DownloadWorker(QObject):
 
                     item_path = format_item_path(item, item_metadata)
                 except (Exception, KeyError) as e:
-                    logger.error(f"Failed to fetch metadata for '{item_id}', Error: {str(e)}\nTraceback: {traceback.format_exc()}")
+                    error_msg = f"Failed to fetch metadata for '{item_id}', Error: {str(e)}"
+                    if "Max retries" in str(e) or "exhausted" in str(e):
+                        error_msg += " (Rate limit exceeded - please try again later or reduce concurrent downloads)"
+                    logger.error(error_msg + f"\nTraceback: {traceback.format_exc()}")
                     item['item_status'] = "Failed"
                     self.tr("Failed")
                     if self.gui:

--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -114,6 +114,10 @@ class Config:
             "maximum_download_workers": 1, # Maximum number of download workers
             "enable_retry_worker": False, # Enable retry worker, automatically retries failed downloads after a set time
             "retry_worker_delay": 10, # Amount of time to wait before retrying failed downloads, in minutes
+            "api_retry_max_attempts": 3, # Max retries on rate limit (429)
+            "api_retry_base_delay": 2, # Base delay for exponential backoff (seconds)
+            "api_retry_max_delay": 60, # Max delay between retries (seconds)
+            "api_request_delay": 0.1, # Delay between consecutive API calls (seconds)
 
             # Search Settings
             "enable_search_tracks": True, # Enable listed category in search

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -5,6 +5,8 @@ import platform
 import requests
 import ssl
 import subprocess
+import threading
+import time
 from hashlib import md5
 from io import BytesIO
 from PIL import Image
@@ -16,6 +18,9 @@ from .otsconfig import config
 from .runtimedata import get_logger, pending, download_queue
 
 logger = get_logger("utils")
+
+# Global lock to serialize API requests across all workers
+_api_request_lock = threading.Lock()
 
 
 class SSLAdapter(requests.adapters.HTTPAdapter):
@@ -54,18 +59,67 @@ def make_call(url, params=None, headers=None, session=None, skip_cache=False, te
         ctx.verify_mode = ssl.CERT_REQUIRED
         session.mount('https://', SSLAdapter(ssl_context=ctx))
 
-    response = session.get(url, headers=headers, params=params)
+    # Retry logic with exponential backoff
+    max_retries = config.get('api_retry_max_attempts', 3)
+    base_delay = config.get('api_retry_base_delay', 2)
+    max_delay = config.get('api_retry_max_delay', 60)
 
-    if response.status_code == 200:
-        if not skip_cache:
-            with open(req_cache_file, 'w', encoding='utf-8') as cf:
-                cf.write(response.text)
-        if text:
-            return response.text
-        return json.loads(response.text)
-    else:
-        logger.info(f"Request status error {response.status_code}: {url}")
-        return None
+    # Use global lock to serialize API requests across all workers
+    # This ensures only one request happens at a time and rate limits are respected globally
+    with _api_request_lock:
+        for attempt in range(max_retries):
+            try:
+                response = session.get(url, headers=headers, params=params, timeout=30)
+
+                # Handle rate limiting (429)
+                if response.status_code == 429:
+                    # Check for Retry-After header
+                    retry_after = response.headers.get('Retry-After')
+                    if retry_after and retry_after.isdigit():
+                        delay = int(retry_after) + 1  # Add 1 second buffer
+                        logger.warning(f"Rate limited (429) on {url}. Retry-After header: {delay}s. Retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                    else:
+                        # Exponential backoff: 2^attempt * base_delay
+                        delay = min((2 ** attempt) * base_delay, max_delay)
+                        logger.warning(f"Rate limited (429) on {url}. No Retry-After header, using exponential backoff. Retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+
+                    time.sleep(delay)
+                    continue
+
+                # Handle server errors with retry (500, 502, 503, 504)
+                elif response.status_code in (500, 502, 503, 504):
+                    delay = min((2 ** attempt) * base_delay, max_delay)
+                    logger.warning(f"Server error ({response.status_code}) on {url}. Retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                    time.sleep(delay)
+                    continue
+
+                # Success - cache and return
+                elif response.status_code == 200:
+                    if not skip_cache:
+                        with open(req_cache_file, 'w', encoding='utf-8') as cf:
+                            cf.write(response.text)
+                    if text:
+                        return response.text
+                    return json.loads(response.text)
+
+                # Other errors - don't retry
+                else:
+                    logger.info(f"Request error {response.status_code}: {url}")
+                    return None
+
+            except requests.exceptions.Timeout:
+                delay = min((2 ** attempt) * base_delay, max_delay)
+                logger.warning(f"Timeout on {url}. Retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                time.sleep(delay)
+                continue
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Request exception on {url}: {str(e)}")
+                return None
+
+        # All retries exhausted - raise exception so it's properly handled
+        error_msg = f"Max retries ({max_retries}) exhausted for {url}"
+        logger.error(error_msg)
+        raise requests.exceptions.RequestException(error_msg)
 
 
 def format_local_id(item_id):


### PR DESCRIPTION
Downloads were failing with no clear indication why (#269). After digging through logs, discovered the app was hitting Spotify's API rate limits (HTTP 429 responses). Here's the problems I encountered that I thought should be fixed:

- Downloads failed and app kept blindly retrying in an infinite loop
- UI never indicated there was a failure
- Multiple workers would hit rate limits simultaneously and all retry at once, making the problem worse
- The `Retry-After` header ([Spotify's guidance on when to retry](https://developer.spotify.com/documentation/web-api/concepts/rate-limits)) was being ignored

This PR fixes the rate limiting issues by implementing automatic retry with exponential backoff, respecting Spotify's rate limit guidance, and serializing API requests across workers to prevent simultaneous hits.

**NOTE:** This has not resulted in restoring functionality (I'm still getting 429s across the board). However, the front-end/UI accurately reports this state which is an improvement (and I hope will help other developers debug and work on this further).

## Changes Made

- Added .DS_Store to .gitignore for easier development on OSX
- Detects HTTP 429 responses and automatically retries with exponential backoff
- Respects Spotify's `Retry-After` header with +1 second buffer when provided
- Serializes all API requests globally across workers to prevent simultaneous rate limit hits
- Added configurable throttling delay between consecutive API calls (default 100ms)
- Enhanced logging shows `Retry-After` header presence and value
- Failed items now show descriptive "Failed" status in UI with rate limit context
- Distinguishes permanent failures (max retries exhausted) from transient errors
- Handles server errors (500-504) with same retry mechanism

### Config Options Added

Four new settings in `otsconfig.py`:
- `api_retry_max_attempts` (default: 3)
- `api_retry_base_delay` (default: 2s)
- `api_retry_max_delay` (default: 60s)
- `api_request_delay` (default: 0.1s)

## Log Output

Here's how the logs look now (note how the `Retry-After` value is included as well as the `Max retries (3) exhausted` at the bottom signifying repeated failures):

```
[2025-12-22 20:44:46,289 :: gui :: onthespot/gui.py -> 48:                main() :: INFO] -> OnTheSpot Version: v1.1.4
[2025-12-22 20:44:46,507 :: gui.main_ui :: onthespot/qt/mainui.py -> 141:            __init__() :: INFO] -> Initialising main window, logging session : 6ee4fd81-459f-4a97-9f28-98ca687f132b
[2025-12-22 20:44:46,507 :: gui.main_ui :: onthespot/qt/mainui.py -> 141:            __init__() :: INFO] -> Initialising main window, logging session : 6ee4fd81-459f-4a97-9f28-98ca687f132b
[2025-12-22 20:44:46,507 :: gui.main_ui :: onthespot/qt/mainui.py -> 144:            __init__() :: INFO] -> Loading configurations..
[2025-12-22 20:44:46,507 :: gui.main_ui :: onthespot/qt/mainui.py -> 144:            __init__() :: INFO] -> Loading configurations..
[2025-12-22 20:44:46,521 :: api.bandcamp :: onthespot/api/bandcamp.py -> 13: bandcamp_login_user() :: INFO] -> Logging into Bandcamp account...
[2025-12-22 20:44:46,521 :: downloader :: onthespot/downloader.py -> 77:               start() :: INFO] -> Starting Download Worker
[2025-12-22 20:44:46,522 :: gui.main_ui :: onthespot/qt/mainui.py -> 178:            __init__() :: INFO] -> Main window init completed !
[2025-12-22 20:44:46,522 :: gui.main_ui :: onthespot/qt/mainui.py -> 178:            __init__() :: INFO] -> Main window init completed !
[2025-12-22 20:44:46,653 :: api.soundcloud :: onthespot/api/soundcloud.py -> 32:soundcloud_login_user() :: INFO] -> Logging into Soundcloud account...
[2025-12-22 20:44:47,268 :: api.youtube_music :: onthespot/api/youtube_music.py -> 13:youtube_music_login_user() :: INFO] -> Logging into Youtube account...
[2025-12-22 20:44:47,825 :: api.spotify :: onthespot/api/spotify.py -> 176:  spotify_login_user() :: INFO] -> Login information for 'foo*******' written to /Users/user/.cache/onthespot/sessions/ots_login_e04a9cfc-4b5a-4bef-adeb-e49c83d8ea81.json
[2025-12-22 20:44:49,932 :: api.spotify :: onthespot/api/spotify.py -> 189:  spotify_login_user() :: INFO] -> Login successful for user 'foo*******'
[2025-12-22 20:44:49,954 :: gui.main_ui :: onthespot/qt/mainui.py -> 389:  fill_account_table() :: INFO] -> Accounts table was populated !
[2025-12-22 20:44:49,954 :: gui.main_ui :: onthespot/qt/mainui.py -> 389:  fill_account_table() :: INFO] -> Accounts table was populated !
[2025-12-22 20:45:07,473 :: search :: onthespot/search.py -> 28:  get_search_results() :: INFO] -> Search clicked with value with url https://open.spotify.com/track/{cached-track-id}
[2025-12-22 20:45:07,594 :: parse_item :: onthespot/parse_item.py -> 170:       parsingworker() :: INFO] -> Parsing: {'item_url': 'https://open.spotify.com/track/{cached-track-id}', 'item_service': 'spotify', 'item_type': 'track', 'item_id': '{cached-track-id}'}
[2025-12-22 20:45:08,274 :: api.spotify :: onthespot/api/spotify.py -> 446:spotify_get_album_track_ids() :: INFO] -> Getting tracks from album: {album-id}
[2025-12-22 20:45:08,882 :: api.spotify :: onthespot/api/spotify.py -> 446:spotify_get_album_track_ids() :: INFO] -> Getting tracks from album: {album-id}
[2025-12-22 20:45:09,113 :: downloader :: onthespot/downloader.py -> 249:                 run() :: INFO] -> File already exists, Skipping download for track by id '{cached-track-id}'
[2025-12-22 20:45:26,689 :: search :: onthespot/search.py -> 28:  get_search_results() :: INFO] -> Search clicked with value with url https://open.spotify.com/track/{failed-track-id}
[2025-12-22 20:45:26,760 :: parse_item :: onthespot/parse_item.py -> 170:       parsingworker() :: INFO] -> Parsing: {'item_url': 'https://open.spotify.com/track/{failed-track-id}', 'item_service': 'spotify', 'item_type': 'track', 'item_id': '{failed-track-id}'}
[2025-12-22 20:45:27,049 :: utils :: onthespot/utils.py -> 80:           make_call() :: WARNING] -> Rate limited (429) on https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token. Retry-After header: 7s. Retrying in 7s (attempt 1/3)
[2025-12-22 20:45:34,107 :: utils :: onthespot/utils.py -> 80:           make_call() :: WARNING] -> Rate limited (429) on https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token. Retry-After header: 60s. Retrying in 60s (attempt 2/3)
[2025-12-22 20:46:34,165 :: utils :: onthespot/utils.py -> 80:           make_call() :: WARNING] -> Rate limited (429) on https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token. Retry-After header: 60s. Retrying in 60s (attempt 3/3)
[2025-12-22 20:47:34,170 :: utils :: onthespot/utils.py -> 121:           make_call() :: ERROR] -> Max retries (3) exhausted for https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token
[2025-12-22 20:47:34,172 :: gui.main_ui :: onthespot/qt/mainui.py -> 100:                 run() :: ERROR] -> Unknown Exception for {'local_id': '{failed-track-id}-0', 'item_service': 'spotify', 'item_type': 'track', 'item_id': '{failed-track-id}', 'parent_category': 'track'}: Max retries (3) exhausted for https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token
Traceback: Traceback (most recent call last):
  File "onthespot/qt/mainui.py", line 90, in run
  File "onthespot/api/spotify.py", line 538, in spotify_get_track_metadata
  File "onthespot/utils.py", line 122, in make_call
requests.exceptions.RequestException: Max retries (3) exhausted for https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token

[2025-12-22 20:47:34,172 :: gui.main_ui :: onthespot/qt/mainui.py -> 100:                 run() :: ERROR] -> Unknown Exception for {'local_id': '{failed-track-id}-0', 'item_service': 'spotify', 'item_type': 'track', 'item_id': '{failed-track-id}', 'parent_category': 'track'}: Max retries (3) exhausted for https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token
Traceback: Traceback (most recent call last):
  File "onthespot/qt/mainui.py", line 90, in run
  File "onthespot/api/spotify.py", line 538, in spotify_get_track_metadata
  File "onthespot/utils.py", line 122, in make_call
requests.exceptions.RequestException: Max retries (3) exhausted for https://api.spotify.com/v1/tracks?ids={failed-track-id}&market=from_token

[2025-12-22 20:47:34,172 :: gui.main_ui :: onthespot/qt/mainui.py -> 104:                 run() :: WARNING] -> Permanent failure detected for {failed-track-id}, will not retry. Adding to download list as Failed.
[2025-12-22 20:47:34,172 :: gui.main_ui :: onthespot/qt/mainui.py -> 104:                 run() :: WARNING] -> Permanent failure detected for {failed-track-id}, will not retry. Adding to download list as Failed.
```

