### PR TITLE
Replaces PR #300

### DIFF
--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -631,7 +631,7 @@ def spotify_get_search_results(token, search_term, content_types, filter_tracks=
                     artist_normalized = item['artists'][0]['name'].lower().removeprefix(prefix).strip()
                     
                     if term_normalized not in title_normalized and term_normalized not in artist_normalized:
-                        logger.info(f"TRACK REJECTED Prefix: {prefix} : Search Term: {term_normalized} : Title: {title_normalized} : Arttist: {artist_normalized}") 
+                        logger.info(f"TRACK REJECTED Prefix: {prefix} : Search Term: {term_normalized} : Title: {title_normalized} : Artist: {artist_normalized}") 
                         rejected_tracks += 1
                         continue
                 

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -609,6 +609,8 @@ def spotify_get_search_results(token, search_term, content_types, filter_tracks=
     rejected_artists = 0
     rejected_tracks = 0
     rejected_playlists = 0
+    # set article stripped from items for filters
+    prefix = "the "
 
     data = requests.get(f"{BASE_URL}/search", params=params, headers=headers).json()   
     search_results = []
@@ -622,99 +624,80 @@ def spotify_get_search_results(token, search_term, content_types, filter_tracks=
                 continue
 #TRACKS               
             if item_type == "track":
-                '''
-                Keep only tracks where either title or artist contains the search term (with or without "the ")
-                '''
-                if filter_tracks:
-                    item_title = item['name']
-                    artist_name = item['artists'][0]['name']
-                    # Normalize search term and item values for comparison
-                    term = search_term.lower()
-                    term_without_the = term.removeprefix("the ")
-                    title_lower = item_title.lower()
-                    artist_lower = artist_name.lower()
-                    # Remove "the " prefix if present for comparison
-                    title_without_the = title_lower.removeprefix("the ")
-                    artist_without_the = artist_lower.removeprefix("the ")
-                    # Check if either title or artist matches the search term (with or without "the ")
-                    if not (term in title_lower or term_without_the in title_without_the or term in artist_lower or term_without_the in artist_without_the):
-                        # logger.info(f"REJECTED > Track Names : '{item_title}' - Artist : '{artist_name}'")
+                if filter_tracks:  
+                    # Keep only tracks where title or artist contains search term (ignoring 'the ' prefix)
+                    term_normalized = search_term.lower().removeprefix(prefix).strip()
+                    title_normalized = item['name'].lower().removeprefix(prefix).strip()
+                    artist_normalized = item['artists'][0]['name'].lower().removeprefix(prefix).strip()
+                    
+                    if term_normalized not in title_normalized and term_normalized not in artist_normalized:
+                        # logger.info(f"REJECTED > Track: '{item['name']}' - Artist: '{item['artists'][0]['name']}'")
                         rejected_tracks += 1
-                        continue  # Skip this item
-                # logger.info(f"Track Names : '{item_title}' - Artist : '{artist_name}'")
+                        continue
+                
                 item_name = f"{config.get('explicit_label') if item['explicit'] else ''} {item['name']}"
                 item_by = f"{config.get('metadata_separator').join([artist['name'] for artist in item['artists']])}"
-                item_thumbnail_url = item['album']['images'][-1]["url"] if len(item['album']['images']) > 0 else ""
+                item_thumbnail_url = item['album']['images'][-1]["url"] if item['album']['images'] else ""
+                # logger.info(f"Track OK - Track Name is '{item['name']}' Artist Name is '{item['artists'][0]['name']}'")
 #ALBUMS                
-            elif item_type == "album":
-                '''
-                Keep only Albums where either artist name or album name starts with search term (with / without 'the')
-                '''
+            elif item_type == "album":                
                 if filter_albums:
-                    artist_name = next((artist.get('name', '').lower() for artist in item.get('artists', [])), '')
-                    term = search_term.lower()
-                    # Remove "the" prefix from artist and album names
-                    artist_name_without_the = artist_name.removeprefix("the ").strip()
-                    album_name = item['name'].lower()
-                    album_name_without_the = album_name.removeprefix("the ").strip()
-                    # Check if artist name or album name starts with the term (allowing additional text after)
-                    artist_matches = artist_name_without_the.startswith(term) or artist_name.startswith(term)
-                    album_matches = album_name_without_the.startswith(term) or album_name.startswith(term)
-                    if not (artist_matches or album_matches):
-                        # logger.info(f"Album rejected - artist_name was : '{artist_name}' Album name was {item['name']}")
+                    # Keep only albums where artist name OR album name starts with search term (ignoring 'the ' prefix)
+                    term_normalized = search_term.lower().removeprefix(prefix).strip()
+                    artist_normalized = item['artists'][0]['name'].lower().removeprefix(prefix).strip()
+                    album_normalized = item['name'].lower().removeprefix(prefix).strip()
+                    
+                    artist_match = artist_normalized.startswith(term_normalized)
+                    album_match = album_normalized.startswith(term_normalized)
+                    
+                    if not artist_match and not album_match:
+                        # logger.info(f"Album rejected - artist: '{item['artists'][0]['name']}', album: '{item['name']}'")
                         rejected_albums += 1
                         continue
-                    # logger.info(f"Album OK - artist_name is : '{artist_name}' Album name is {item['name']} ")
                 
                 rel_year = re.search(r'(\d{4})', item['release_date']).group(1)
                 item_name = f"[Y:{rel_year}] [T:{item['total_tracks']}] {item['name']}"
                 item_by = f"{config.get('metadata_separator').join([artist['name'] for artist in item['artists']])}"
-                item_thumbnail_url = item['images'][-1]["url"] if len(item['images']) > 0 else ""
+                item_thumbnail_url = item['images'][-1]["url"] if item['images'] else ""
+                # logger.info(f"Album OK - artist: '{item['artists'][0]['name']}' Album: '{item['name']}'")
 #PLAYLISTS                
             elif item_type == "playlist":
-                '''
-                Keep only Playlists where name contains search term (with / without 'the')
-                '''
-                item_by = f"{item['owner']['display_name']}" 
-                playlist_name = item['name'] 
-                if filter_playlists:                                    
-                    # Normalize search term and playlist name for comparison
-                    term = search_term.lower()
-                    term_without_the = term[4:] if term.startswith("the ") else term                
-                    playlist_lower = playlist_name.lower()
-                    playlist_without_the = playlist_lower[4:] if playlist_lower.startswith("the ") else playlist_lower              
-                    # Check if playlist name matches the search term (with or without "the ")
-                    if not (term in playlist_lower or term_without_the in playlist_without_the):
+                if filter_playlists:
+                    # Keep only playlists where name contains search term (ignoring 'the ' prefix)
+                    term_normalized = search_term.lower().removeprefix(prefix).strip()
+                    playlist_normalized = item['name'].lower().removeprefix(prefix).strip()
+                    
+                    if term_normalized not in playlist_normalized:
                         rejected_playlists += 1
-                        # logger.info(f"Playlist rejected : '{playlist_name}' by '{item_by}'")
+                        # logger.info(f"Playlist rejected: '{item['name']}' by '{item['owner']['display_name']}'")
                         continue
-                item_tracks = f"{item['tracks']['total']}"
-                # Add number of tracks in playlist
-                item_name = f"[T:{item_tracks}] {item['name']}"      
-                item_thumbnail_url = item['images'][-1]["url"] if len(item['images']) > 0 else ""
-                # logger.info(f"Playlist found : '{playlist_name}' - Tracks: {item_tracks}")
-#ARTISTS                
+                
+                item_name = f"[T:{item['tracks']['total']}] {item['name']}"
+                item_by = f"{item['owner']['display_name']}"
+                item_thumbnail_url = item['images'][-1]["url"] if item['images'] else ""
+                # logger.info(f"Playlist OK: '{item['name']}' - Tracks: {item['tracks']['total']}")
+#ARTISTS    
             elif item_type == "artist":
-                '''
-                Keep only artists where name matches search term (with / without 'the')
-                '''
                 if filter_artists:
-                    name = item['name'].lower()
-                    term = search_term.lower()
-                    name_without_the = name.removeprefix("the ").strip()
-                    if name_without_the != term and name != term:
-                        # logger.info(f"Artist rejected - artist_name was : '{name}'")
+                    # Keep only artists where name starts with search term (ignoring 'the ' prefix)
+                    name_normalized = item['name'].lower().removeprefix(prefix).strip()
+                    term_normalized = search_term.lower().removeprefix(prefix).strip()
+                    
+                    if not name_normalized.startswith(term_normalized):
+                        # logger.info(f"Artist rejected - artist_name was : '{item['name']}'")
                         rejected_artists += 1
                         continue
+                
+                # Build item name with genres if available
                 item_name = item['name']
-                logger.info(f"Artist OK - artist_name is : '{item_name}'")
                 try:
                     if f"{'/'.join(item['genres'])}" != "":
                         item_name = item['name'] + f"  |  GENERES: {'/'.join(item['genres'])}"
                 except:
-                    logger.warning("No genre tag found for %s", item['name'])
-                item_by = f"{item['name']}"
-                item_thumbnail_url = item['images'][-1]["url"] if len(item['images']) > 0 else ""                             
+                    logger.warning("No genre tag found for %s", item['name'])                
+                item_by = item['name']
+                item_thumbnail_url = item['images'][-1]["url"] if item['images'] else ""
+                # logger.info(f"Artist OK - artist_name is : '{item['name']}'")                
 #SHOWS                
             elif item_type == "show":
                 item_name = f"{config.get('explicit_label') if item['explicit'] else ''} {item['name']}"
@@ -742,16 +725,15 @@ def spotify_get_search_results(token, search_term, content_types, filter_tracks=
                 'item_url': item['external_urls']['spotify'],
                 'item_thumbnail_url': item_thumbnail_url
             })
+            
 #REJECTION LOGGING - logs number of items rejected by filters
-    rejection_msg = ' '.join([
-        f"{label}:{count}" 
-        for label, count in [
-            ("Tracks", rejected_tracks),
-            ("Artists", rejected_artists),
-            ("Albums", rejected_albums),
-            ("Playlists", rejected_playlists)
-        ] if count > 0
-    ])
+    rejections = {
+        "Tracks": rejected_tracks,
+        "Artists": rejected_artists,
+        "Albums": rejected_albums,
+        "Playlists": rejected_playlists
+    }
+    rejection_msg = ' '.join([f"{label}:{count}" for label, count in rejections.items() if count > 0])
     if rejection_msg:
         logger.info(f"REJECTED - {rejection_msg}")
     else:

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -690,10 +690,10 @@ def spotify_get_search_results(token, search_term, content_types, filter_tracks=
                 # Build item name with genres if available
                 item_name = item['name']
                 try:
-                    if f"{'/'.join(item['genres'])}" != "":
-                        item_name = item['name'] + f"  |  GENERES: {'/'.join(item['genres'])}"
-                except:
-                    logger.warning("No genre tag found for %s", item['name'])                
+                    if item['genres']:
+                        item_name = item['name'] + f"  |  GENRES: {'/'.join(item['genres'])}"
+                except (KeyError, TypeError):
+                    logger.warning("No genre tag found for %s", item['name'])               
                 item_by = item['name']
                 item_thumbnail_url = item['images'][-1]["url"] if item['images'] else ""
                 # logger.info(f"Artist OK - artist_name is : '{item['name']}'")                

--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -139,6 +139,8 @@ class Config:
             "f_search_albums": False,  # Enable filtered Albums search
             "f_search_artists": False,  # Enable filtered Artists search
             "f_search_playlists": False,  # Enable filtered Playlists search
+            # Search Prefix Settings
+            "search_prefix": "the" ,
             # Download Queue Filter Settings
             "download_queue_show_waiting": True,  # Enable listed filter in download queue
             "download_queue_show_failed": True,  # Enable listed filter in download queue
@@ -289,6 +291,7 @@ class Config:
                 self.app_root, "bin", "ffmpeg", "ffmpeg" + self.ext_
             ),  # BUNDLED
         ]
+        ffmpeg_path = ""
         for path in ffmpeg_path_candidates:
             if os.path.isfile(path) and os.access(path, os.X_OK):
                 ffmpeg_path = path
@@ -297,7 +300,7 @@ class Config:
             print(
                 "Failed to find ffmpeg binary, please consider installing ffmpeg or defining its path by setting FFMPEG_PATH."
             )
-            ffmpeg_path = ""
+        
         print(f"FFMPEG Binary: {ffmpeg_path}")
         self.set("_ffmpeg_bin_path", ffmpeg_path)
         self.set(

--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import uuid
 
 
@@ -284,6 +285,7 @@ class Config:
         self.app_root = os.path.dirname(os.path.realpath(__file__))
         ffmpeg_path_candidates = [
             os.environ.get("FFMPEG_PATH", ""),  # ENV
+            shutil.which("ffmpeg") or "",        # SYSTEM PATH
             "/usr/bin/ffmpeg",  # UNIX
             "/opt/homebrew/bin/ffmpeg",  # MACOS ARM
             "/usr/local/bin/ffmpeg",  # MACOS INTEL

--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -1086,7 +1086,8 @@ class MainWindow(QMainWindow):
             filter_tracks=self.f_search_tracks.isChecked(),
             filter_albums=self.f_search_albums.isChecked(),
             filter_artists=self.f_search_artists.isChecked(),
-            filter_playlists=self.f_search_playlists.isChecked()
+            filter_playlists=self.f_search_playlists.isChecked(),
+            search_prefix=self.search_prefix.text()
         )
         if results is None:
             self.show_popup_dialog(self.tr("You need to login to at least one account to use this feature."))

--- a/src/onthespot/qt/qtui/main.ui
+++ b/src/onthespot/qt/qtui/main.ui
@@ -349,6 +349,54 @@
 				   </widget>
 				  </item>
 				  <item>
+			   <spacer name="horizontalSpacer_before_prefix">
+				<property name="orientation">
+				 <enum>Qt::Horizontal</enum>
+				</property>
+				<property name="sizeHint" stdset="0">
+				 <size>
+				  <width>120</width>
+				  <height>20</height>
+				 </size>
+				</property>
+			   </spacer>
+			  </item>
+				  <item>
+				   <widget class="QLabel" name="label_search_prefix">
+				    <property name="toolTip">
+					 <string>Article (prefix) to trim from the search terms for filtering searches&#xa;A trailing space will be added if you do not include one</string>
+					</property>
+					<property name="text">
+					 <string>Search Prefix:</string>
+					</property>
+				   </widget>
+				  </item>
+				  <item>
+				   <widget class="QLineEdit" name="search_prefix">
+				    <property name="toolTip">
+					 <string>Article (prefix) to trim from the search terms for filtering searches&#xa;A trailing space will be added if you do not include one</string>
+					</property>
+					<property name="minimumSize">
+					 <size>
+					  <width>100</width>
+					  <height>0</height>
+					 </size>
+					</property>
+					<property name="maximumSize">
+					 <size>
+					  <width>150</width>
+					  <height>16777215</height>
+					 </size>
+					</property>
+					<property name="text">
+					 <string>the </string>
+					</property>
+					<property name="placeholderText">
+					 <string>the </string>
+					</property>
+				   </widget>
+				  </item>
+				  <item>
 				   <spacer name="horizontalSpacer_search_filters">
 					<property name="orientation">
 					 <enum>Qt::Horizontal</enum>

--- a/src/onthespot/qt/settings.py
+++ b/src/onthespot/qt/settings.py
@@ -141,10 +141,15 @@ def load_config(self):
     self.enable_search_episodes.setChecked(config.get("enable_search_episodes"))
     self.enable_search_podcasts.setChecked(config.get("enable_search_podcasts"))
     self.enable_search_audiobooks.setChecked(config.get("enable_search_audiobooks"))
+
+    # Search Filter Settings
     self.f_search_tracks.setChecked(config.get("f_search_tracks"))
     self.f_search_albums.setChecked(config.get("f_search_albums"))
     self.f_search_artists.setChecked(config.get("f_search_artists"))    
     self.f_search_playlists.setChecked(config.get("f_search_playlists"))
+    
+    # Search Filter prefix Settings
+    self.search_prefix.setText(config.get("search_prefix", "the "))
 
     # Download Queue Filter Settings
     self.download_queue_show_waiting.setChecked(config.get("download_queue_show_waiting"))
@@ -281,10 +286,15 @@ def save_config(self):
     config.set('enable_search_episodes', self.enable_search_episodes.isChecked())
     config.set('enable_search_podcasts', self.enable_search_podcasts.isChecked())
     config.set('enable_search_audiobooks', self.enable_search_audiobooks.isChecked())
+    
+    # Search Filter Settings
     config.set('f_search_tracks', self.f_search_tracks.isChecked())
     config.set('f_search_artists', self.f_search_artists.isChecked())
     config.set('f_search_albums', self.f_search_albums.isChecked())
     config.set('f_search_playlists', self.f_search_playlists.isChecked())
+    
+    # Search Filter prefix Settings
+    config.set("search_prefix", self.search_prefix.text())
 
     # Download Queue Filter Settings
     config.set('download_queue_show_waiting', self.download_queue_show_waiting.isChecked())

--- a/src/onthespot/search.py
+++ b/src/onthespot/search.py
@@ -16,7 +16,7 @@ from .runtimedata import account_pool, get_logger
 logger = get_logger("search")
 
 
-def get_search_results(search_term, content_types=None, filter_tracks=True, filter_albums=True, filter_artists=True, filter_playlists=True):
+def get_search_results(search_term, content_types=None, filter_tracks=True, filter_albums=True, filter_artists=True, filter_playlists=True, search_prefix="the"):
     if len(account_pool) <= 0:
         return None
 
@@ -52,7 +52,8 @@ def get_search_results(search_term, content_types=None, filter_tracks=True, filt
                 filter_tracks,
                 filter_albums,
                 filter_artists,
-                filter_playlists
+                filter_playlists,
+                search_prefix
             )
         else:
             return False


### PR DESCRIPTION
Replaces PR #300
Add 'prefix' variable to set the article used by filters.
Broaden the Artist check in Filter Albums by stripping 'prefix' from the search term when comparing artist names.
Removed slice and replaced with .removeprefix(prefix) for consistency
Make all filters consistent with consistent naming.
Simplified to only compare normalized versions - removed the redundant check with original term
Simplified thumbnail check - if item['images'] instead of if len(item['images']) > 0