### PR TITLE
Fix Deezer/Bandcamp/YouTube/Crunchyroll service path.  Improve Spotify API logging and search routing

### DIFF
--- a/.github/workflows/release-builder-clean-spotify.yml
+++ b/.github/workflows/release-builder-clean-spotify.yml
@@ -1,0 +1,167 @@
+name: Release Builder clean-spotify
+
+on:
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+
+jobs:
+  windows-x86_64-build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: clean-spotify
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Run Windows Build Script
+        run: scripts\build_windows.bat
+        shell: cmd
+
+      - name: Upload Windows Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.exe
+          path: dist/OnTheSpot.exe
+
+      - name: Upload to Release (Windows)
+        if: ${{ github.event.release.prerelease == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.exe
+          asset_name: OnTheSpot-x86_64.exe
+          asset_content_type: application/octet-stream
+
+  macos-x86_64-build:
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: clean-spotify
+
+      - name: Run macOS Build Script
+        run: scripts/build_mac.sh
+        shell: bash
+
+      - name: Upload macOS DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.dmg
+          path: dist/OnTheSpot.dmg
+
+      - name: Upload to Release (macOS)
+        if: ${{ github.event.release.prerelease == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.dmg
+          asset_name: OnTheSpot-x86_64.dmg
+          asset_content_type: application/x-apple-diskimage
+
+  macos-arm64-build:
+    runs-on: macos-15
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: clean-spotify
+
+      - name: Run macOS Build Script
+        run: scripts/build_mac.sh
+        shell: bash
+
+      - name: Upload macOS DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-arm64.dmg
+          path: dist/OnTheSpot.dmg
+
+      - name: Upload to Release (macOS)
+        if: ${{ github.event.release.prerelease == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.dmg
+          asset_name: OnTheSpot-arm64.dmg
+          asset_content_type: application/x-apple-diskimage
+
+  linux-x86_64-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: clean-spotify
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf fuse libfuse2 wget
+
+      - name: Run Linux Build Script
+        run: scripts/build_linux.sh
+        shell: bash
+
+      - name: Upload Linux Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.tar.gz
+          path: dist/OnTheSpot.tar.gz
+
+      - name: Upload to Release (Linux)
+        if: ${{ github.event.release.prerelease == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot.tar.gz
+          asset_name: OnTheSpot-x86_64.tar.gz
+          asset_content_type: application/gzip
+
+  appimage-x86_64-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: clean-spotify
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgssapi-krb5-2 libxcb-cursor0 libxcb-xinerama0 libxcb1 ffmpeg desktop-file-utils fuse patchelf wget
+
+      - name: Run AppImage Build Script
+        run: scripts/build_appimage.sh
+        shell: bash
+
+      - name: Upload AppImage Executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: OnTheSpot-x86_64.AppImage
+          path: dist/OnTheSpot-x86_64.AppImage
+
+      - name: Upload to Release (AppImage)
+        if: ${{ github.event.release.prerelease == true }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/OnTheSpot-x86_64.AppImage
+          asset_name: OnTheSpot-x86_64.AppImage
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-builder-clean-spotify.yml
+++ b/.github/workflows/release-builder-clean-spotify.yml
@@ -1,8 +1,8 @@
 name: Release Builder clean-spotify
 
 on:
-  release:
-    types: [prereleased]
+#  release:
+#    types: [prereleased]
   workflow_dispatch:
 
 jobs:

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -753,9 +753,18 @@ def spotify_get_track_metadata(token, item_id):
         return None
 
     headers = auth_header
-    logger.info(f"[API Call 1/6] Fetching track data for track_id={item_id}")
+
+    #Calculate number of API calls required
+    api_total_calls = 1   
+    if config.get('fetch_extended_album_metadata', True):
+        api_total_calls += 1
+    if config.get('fetch_genre_metadata', True):
+        api_total_calls += 1    
+    call_num = 1
+    logger.info(f"[API Call {call_num}/{api_total_calls}] Fetching track data for track_id={item_id}")
     track_data = make_call(f'{BASE_URL}/tracks?ids={item_id}', headers=headers)
     time.sleep(config.get('api_request_delay', 0.1))
+    call_num += 1
 
     # Use embedded album data (album_type, name, images, total_tracks already available)
     album_data = track_data.get('tracks', [])[0].get('album', {})
@@ -763,18 +772,20 @@ def spotify_get_track_metadata(token, item_id):
     # Only fetch full album if we need label/copyright (optional fields)
     if config.get('fetch_extended_album_metadata', True):
         album_id = track_data.get('tracks', [])[0].get('album', {}).get('id')
-        logger.info(f"[API Call 2/6] Fetching extended album metadata for album_id={album_id}")
+        logger.info(f"[API Call {call_num}/{api_total_calls}] Fetching extended album metadata for album_id={album_id}")
         full_album = make_call(f"{BASE_URL}/albums/{album_id}", headers=headers)
         time.sleep(config.get('api_request_delay', 0.1))
+        call_num += 1
         album_data = full_album  # Use full data if fetched
 
     # Fetch artist data only if genre metadata is enabled
     artist_data = {}
     if config.get('fetch_genre_metadata', True):
         artist_id = track_data.get('tracks', [])[0].get('artists', [])[0].get('id')
-        logger.info(f"[API Call 3/6] Fetching artist data for artist_id={artist_id}")
+        logger.info(f"[API Call {call_num}/{api_total_calls}] Fetching artist data for artist_id={artist_id}")
         artist_data = make_call(f"{BASE_URL}/artists/{artist_id}", headers=headers)
         time.sleep(config.get('api_request_delay', 0.1))
+        call_num += 1
 
     # Fetch audio features only if enabled
     track_audio_data = ''

--- a/src/onthespot/search.py
+++ b/src/onthespot/search.py
@@ -43,7 +43,8 @@ def get_search_results(search_term, content_types=None, filter_tracks=True, filt
 
         logger.info(f"Search clicked with value term {search_term}")
         service = account_pool[config.get('active_account_number')]['service']
-        if search_term and service != 'generic':
+        if search_term and service == 'spotify':
+            logger.info(f"Service requested is {service}")
             token = get_account_token(service)
             return globals()[f"{service}_get_search_results"](
                 token, 
@@ -55,5 +56,13 @@ def get_search_results(search_term, content_types=None, filter_tracks=True, filt
                 filter_playlists,
                 search_prefix
             )
+        elif search_term and service != 'generic':
+            logger.info(f"Service requested is {service}")
+            token = get_account_token(service)
+            return globals()[f"{service}_get_search_results"](
+                token, 
+                search_term, 
+                content_types
+            )                      
         else:
             return False


### PR DESCRIPTION
Calculate and display dynamic API call numbering in spotify_get_track_metadata by computing api_total_calls and incrementing call_num between conditional requests, and update log messages accordingly. Also add checks for config flags (fetch_extended_album_metadata, fetch_genre_metadata) to include/exclude calls and respect api_request_delay. In search.get_search_results refine routing: handle the 'spotify' service path explicitly (with logging and token retrieval) and add a separate branch for other non-generic services, ensuring proper dispatch to the service-specific search function.