### PR TITLE
feat: add randomized download delay variance setting

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,7 +73,8 @@ If a file path is provided the app will parse each line in the file for urls beg
 | **Illegal Character Replacement** | Replace illegal characters in the filepath with the value specified (e.g., `/`, `\`, `<`, `>`, `*`, etc.). |
 | **Rotate Active Account** | Automatically rotate between added accounts for downloading to minimize the chance of hitting rate limits. |
 | **Raw Media Download** | Downloads an unmodified file from whatever service is selected. With this enabled file conversion and the embedding of any metadata is skipped. Lyrics and cover art will still be downloaded. |
-| **Download Delay (s)** | The time,in seconds, to wait before initiating the next download. Helps prevent rate limits. |
+| **Download Delay (s)** | The time, in seconds, to wait before initiating the next download. Helps prevent rate limits. |
+| **Download Delay Variance (±s)** | Random variance applied to the download delay. For example, with a delay of 60s and variance of 30s, each download will wait between 30–90 seconds. Set to 0 to disable. |
 | **Download Chunk Size (b)** | The chunk size, in bytes, in which to download files. |
 | **Maximum Queue Workers** | Set the maximum number of queue workers. Setting a higher number will queue songs faster, only change this setting if you know what you're doing. Changes to this setting require you to restart the app take effect. |
 | **Maximum Download Workers** | Set the maximum number of download workers. Only change this setting if you know what you're doing. Changes to this setting require you to restart the app to take effect. |

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -1,3 +1,4 @@
+import random
 import re
 import requests
 import subprocess
@@ -779,7 +780,10 @@ class DownloadWorker(QObject):
                     config.save()
                 except Exception:
                     pass
-                time.sleep(config.get("download_delay"))
+                variance = config.get("download_delay_variance")
+                delay = max(0, config.get("download_delay") + random.randint(-variance, variance))
+                logger.info(f"Waiting {delay}s before next download")
+                time.sleep(delay)
                 self.readd_item_to_download_queue(item)
                 continue
             except Exception as e:
@@ -792,7 +796,10 @@ class DownloadWorker(QObject):
                     if self.gui:
                         self.progress.emit(item, self.tr("Cancelled"), 0)
 
-                time.sleep(config.get("download_delay"))
+                variance = config.get("download_delay_variance")
+                delay = max(0, config.get("download_delay") + random.randint(-variance, variance))
+                logger.info(f"Waiting {delay}s before next download")
+                time.sleep(delay)
                 self.readd_item_to_download_queue(item)
 
                 if os.path.exists(temp_file_path):

--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -107,6 +107,7 @@ class Config:
             "raw_media_download": False,  # Skip media conversion and metadata writing
             "rotate_active_account_number": False,  # Rotate active account for parsing and downloading tracks
             "download_delay": 3,  # Seconds to wait before next download attempt
+            "download_delay_variance": 0,  # Random ± variance in seconds applied to download delay
             "download_chunk_size": 50000,  # Chunk size in bytes to download in
             "maximum_queue_workers": 1,  # Maximum number of queue workers
             "maximum_download_workers": 1,  # Maximum number of download workers

--- a/src/onthespot/qt/qtui/main.ui
+++ b/src/onthespot/qt/qtui/main.ui
@@ -1845,6 +1845,66 @@
                 </widget>
                </item>
                <item>
+                <widget class="QGroupBox" name="gb1_10b">
+                 <property name="title">
+                  <string/>
+                 </property>
+                 <property name="flat">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_241">
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_128b">
+                    <property name="title">
+                     <string/>
+                    </property>
+                    <property name="flat">
+                     <bool>false</bool>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_236">
+                     <item>
+                      <widget class="QLabel" name="lb_download_delay_variance">
+                       <property name="text">
+                        <string>Download Delay Variance (±s)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_47">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>40</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="download_delay_variance">
+                       <property name="minimumSize">
+                        <size>
+                         <width>80</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                       <property name="minimum">
+                        <number>0</number>
+                       </property>
+                       <property name="maximum">
+                        <number>999999</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QGroupBox" name="gb1_11">
                  <property name="title">
                   <string/>

--- a/src/onthespot/qt/settings.py
+++ b/src/onthespot/qt/settings.py
@@ -72,6 +72,7 @@ def load_config(self):
         "retry_worker_delay",
         "file_hertz",
         "download_delay",
+        "download_delay_variance",
         "download_chunk_size",
         "maximum_queue_workers",
         "maximum_download_workers"
@@ -127,6 +128,7 @@ def load_config(self):
     self.raw_media_download.setChecked(config.get("raw_media_download"))
     self.rotate_active_account_number.setChecked(config.get("rotate_active_account_number"))
     self.download_delay.setValue(config.get("download_delay"))
+    self.download_delay_variance.setValue(config.get("download_delay_variance"))
     self.download_chunk_size.setValue(config.get("download_chunk_size"))
     self.maximum_queue_workers.setValue(config.get("maximum_queue_workers"))
     self.maximum_download_workers.setValue(config.get("maximum_download_workers"))
@@ -272,6 +274,7 @@ def save_config(self):
     config.set('raw_media_download', self.raw_media_download.isChecked())
     config.set('rotate_active_account_number', self.rotate_active_account_number.isChecked())
     config.set('download_delay', self.download_delay.value())
+    config.set('download_delay_variance', self.download_delay_variance.value())
     config.set('download_chunk_size', self.download_chunk_size.value())
     config.set('maximum_queue_workers', self.maximum_queue_workers.value())
     config.set('maximum_download_workers', self.maximum_download_workers.value())

--- a/src/onthespot/resources/web/settings.html
+++ b/src/onthespot/resources/web/settings.html
@@ -280,6 +280,14 @@
                 </tr>
                 <tr>
                     <td>
+                        <label for="download_delay_variance">Download Delay Variance (±seconds):</label>
+                    </td>
+                    <td>
+                        <input type="number" id="download_delay_variance" value="{{ config.download_delay_variance }}" min="0" placeholder="Enter delay variance">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label for="download_chunk_size">Download Chunk Size (bytes):</label>
                     </td>
                     <td>
@@ -927,6 +935,7 @@
                     raw_media_download: document.getElementById('raw_media_download').checked,
                     rotate_active_account_number: document.getElementById('rotate_active_account_number').checked,
                     download_delay: document.getElementById('download_delay').value,
+                    download_delay_variance: document.getElementById('download_delay_variance').value,
                     download_chunk_size: document.getElementById('download_chunk_size').value,
                     maximum_queue_workers: document.getElementById('maximum_queue_workers').value,
                     maximum_download_workers: document.getElementById('maximum_download_workers').value,


### PR DESCRIPTION
Add a new "Download Delay Variance (±s)" setting that randomizes the wait time between downloads. Each download independently picks a random delay from [delay - variance, delay + variance], clamped to a minimum of 0 seconds. Defaults to 0 (no variance), preserving existing behavior.

- Add download_delay_variance config default in otsconfig.py
- Randomize both delay points in downloader.py using random.randint
- Log computed delay before each wait for debugging
- Wire up new spinbox in Qt GUI settings (main.ui + settings.py)
- Add input field to web UI settings page
- Document the new setting in USAGE.md