### PR TITLE
feat: add support for {composer} tag with smart path formatting

### DIFF
--- a/.github/workflows/release-builder-beta.yml
+++ b/.github/workflows/release-builder-beta.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: api-feature
+          ref: search-filter-fix
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: api-feature
+          ref: search-filter-fix
 
       - name: Run macOS Build Script
         run: scripts/build_mac.sh
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: api-feature
+          ref: search-filter-fix
 
       - name: Run macOS Build Script
         run: scripts/build_mac.sh
@@ -104,7 +104,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: api-feature
+          ref: search-filter-fix
 
       - name: Install Dependencies
         run: |
@@ -138,7 +138,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: api-feature
+          ref: search-filter-fix
 
       - name: Install Dependencies
         run: |

--- a/src/onthespot/api/apple_music.py
+++ b/src/onthespot/api/apple_music.py
@@ -204,6 +204,7 @@ def apple_music_get_track_metadata(session, item_id):
     info['image_url'] = image_url.replace("{w}", str(max_width)).replace("{h}", str(max_height))
 
     info['writer'] = track_data.get('data', [])[0].get('attributes', {}).get('composerName')
+    info['composer'] = info['writer']
     info['language'] = track_data.get('data', [])[0].get('attributes', {}).get('audioLocale')
     info['item_url'] = track_data.get('data', [])[0].get('attributes', {}).get('url')
     info['is_playable'] = True if track_data.get('data', [])[0].get('attributes', {}).get('playParams') else False

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -604,6 +604,7 @@ def spotify_get_track_metadata(token, item_id):
         info['performers'] = conv_list_format([item for item in credits.get('performers', []) if isinstance(item, str)])
         info['producers'] = conv_list_format([item for item in credits.get('producers', []) if isinstance(item, str)])
         info['writers'] = conv_list_format([item for item in credits.get('writers', []) if isinstance(item, str)])
+        info['composer'] = info['writers']
 
     if track_audio_data:
         key_mapping = {

--- a/src/onthespot/otsconfig.py
+++ b/src/onthespot/otsconfig.py
@@ -170,6 +170,7 @@ class Config:
             "embed_performers": True,
             "embed_producers": True,
             "embed_writers": True,
+            "embed_composer": True,
             "embed_label": True,
             "embed_copyright": True,
             "embed_description": True,

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -149,12 +149,9 @@ def format_item_path(item, item_metadata):
     elif item['item_type'] == 'episode':
         path = config.get("show_path_formatter")
 
-    # Audio
-    artist = sanitize_data(item_metadata.get('artists'))
+    # Split composer
     composer_full = item_metadata.get('composer', '')
     composer_first = re.split(r' [,&;] | & |,|;', composer_full)[0].strip() if composer_full else ''
-    composer = sanitize_data(composer_first)
-    album = sanitize_data(album)
 
     item_path = path.format(
         # Universal
@@ -164,10 +161,11 @@ def format_item_path(item, item_metadata):
         year=sanitize_data(item_metadata.get('release_year')),
         explicit=sanitize_data(str(config.get('explicit_label')) if item_metadata.get('explicit') else ''),
 
+
         # Audio
-        artist=artist,
-        composer=composer,
-        album=album,
+        artist=sanitize_data(item_metadata.get('artists')),
+        composer=sanitize_data(composer_first),
+        album=sanitize_data(album),
         album_artist=sanitize_data(item_metadata.get('album_artists')),
         album_type=item_metadata.get('album_type', 'single').title(),
         disc_number=item_metadata.get('disc_number', 1) if not config.get('use_double_digit_path_numbers') else str(item_metadata.get('disc_number', 1)).zfill(2),

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import platform
+import re
 import requests
 import ssl
 import subprocess
@@ -148,6 +149,13 @@ def format_item_path(item, item_metadata):
     elif item['item_type'] == 'episode':
         path = config.get("show_path_formatter")
 
+    # Audio
+    artist = sanitize_data(item_metadata.get('artists'))
+    composer_full = item_metadata.get('composer', '')
+    composer_first = re.split(r' [,&;] | & |,|;', composer_full)[0].strip() if composer_full else ''
+    composer = sanitize_data(composer_first)
+    album = sanitize_data(album)
+
     item_path = path.format(
         # Universal
         service=sanitize_data(item.get('item_service')).title(),
@@ -157,8 +165,9 @@ def format_item_path(item, item_metadata):
         explicit=sanitize_data(str(config.get('explicit_label')) if item_metadata.get('explicit') else ''),
 
         # Audio
-        artist=sanitize_data(item_metadata.get('artists')),
-        album=sanitize_data(album),
+        artist=artist,
+        composer=composer,
+        album=album,
         album_artist=sanitize_data(item_metadata.get('album_artists')),
         album_type=item_metadata.get('album_type', 'single').title(),
         disc_number=item_metadata.get('disc_number', 1) if not config.get('use_double_digit_path_numbers') else str(item_metadata.get('disc_number', 1)).zfill(2),
@@ -400,6 +409,12 @@ def embed_metadata(item, metadata):
                     command += ['-metadata', 'TEXT={}'.format(value)]
                 else:
                     command += ['-metadata', 'author={}'.format(value)]
+
+            elif key == 'composer' and config.get("embed_composer"):
+                if filetype == '.mp3':
+                    command += ['-metadata', 'TCOM={}'.format(value)]
+                else:
+                    command += ['-metadata', 'composer={}'.format(value)]
 
             elif key == 'label' and config.get("embed_label"):
                 if filetype in ['.flac', '.ogg', '.opus']:
@@ -663,6 +678,7 @@ def add_to_m3u_file(item, item_metadata):
         service=item.get('item_service').title(),
         service_id=str(item.get('item_id')),
         artist=item_metadata.get('artists'),
+        composer=item_metadata.get('composer'),
         album=item_metadata.get('album_name'),
         album_artist=item_metadata.get('album_artists'),
         album_type=item_metadata.get('album_type', 'single').title(),


### PR DESCRIPTION
# Pull Request Description: Add {composer} Tag Support

**Title:** `feat: Add {composer} tag support with smart path formatting`

## Description
This PR adds support for a `{composer}` variable in the track path formatter and metadata embedding. 

### Why this is needed (The Tamil Music/Apple Music Problem)
When downloading soundtracks—specifically Tamil movie songs from Apple Music—the `Album Artist` tag is often inconsistent or missing, while the `Composer` field is almost always populated with the primary music director (e.g., A.R. Rahman, Anirudh). 

Currently, users have to rely on `{artist}`, which can lead to fragmented folder structures if multiple artists are featured on a track. By adding `{composer}`, users can reliably organize their library by the actual music director.

### Key Changes
1. **Metadata Extraction:** Added explicit extraction of `composerName` for Apple Music and `writers` for Spotify credits.
2. **Smart Path Formatting:** Added a logic refinement for the `{composer}` path variable. If the composer field contains multiple names (e.g., `A.R. Rahman & Na. Muthukumar`), the path formatter will only use the **first name** for the folder structure to keep libraries clean.
3. **Full Metadata Preservation:** While the folder path uses the primary name, the **full list of names** is still embedded into the file's internal metadata tags (mapping to `TCOM` for MP3/ID3).
4. **Configuration:** Added an `embed_composer` toggle in the settings.

### Verification Results
- Tested with Apple Music URLs.
- Verified that `Tracks/{composer}/{album}/` correctly creates folders using only the lead composer's name.
- Verified that ID3 tags correctly contain the full composer string via MP3Tag/ffprobe.
