### PR TITLE
route worker GUI updates through signals to avoid SIGSEGV

### DIFF
--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -90,6 +90,7 @@ class RetryWorker(QObject):
     """
 
     progress = pyqtSignal(dict, str, int)
+    item_reset = pyqtSignal(dict)
 
     def __init__(self, gui: bool = False) -> None:
         super().__init__()
@@ -116,9 +117,7 @@ class RetryWorker(QObject):
                         if item["item_status"] == ItemStatus.FAILED:
                             item["item_status"] = ItemStatus.WAITING
                             if self.gui:
-                                item["gui"]["status_label"].setText(self.tr("Waiting"))
-                                item["gui"]["btn"]["cancel"].show()
-                                item["gui"]["btn"]["retry"].hide()
+                                self.item_reset.emit(item)
 
             delay_minutes = config.get("retry_worker_delay")
             if delay_minutes > 0:
@@ -181,12 +180,13 @@ class DownloadWorker(QObject):
 
     def _yt_dlp_progress_hook(self, item: dict, progress_info: dict) -> None:
         """Hook passed to yt-dlp to forward download progress to the GUI."""
-        current = item["gui"]["progress_bar"].value()
+        current = item.get("progress", 0)
         match = re.search(r"(\d+\.\d+)%", progress_info["_percent_str"])
         if not match:
             return
         new_value = round(float(match.group(1))) - 1
         if new_value >= current:
+            item["progress"] = new_value
             self.progress.emit(item, self.tr("Downloading"), new_value)
         if item["item_status"] == ItemStatus.CANCELLED:
             raise Exception("Download cancelled by user.")

--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -248,6 +248,7 @@ class MainWindow(QMainWindow):
 
         if config.get("enable_retry_worker"):
             retryworker = RetryWorker(gui=True)
+            retryworker.item_reset.connect(self.set_item_waiting)
             retryworker.start()
 
         self.mirrorplayback = MirrorSpotifyPlayback()
@@ -1103,6 +1104,12 @@ class MainWindow(QMainWindow):
                     item["gui"]["btn"]["copy"].show()
                 item["gui"]["btn"]["cancel"].show()
                 return
+
+    def set_item_waiting(self, item):
+        with download_queue_lock:
+            item["gui"]["status_label"].setText(self.tr("Waiting"))
+            item["gui"]["btn"]["cancel"].show()
+            item["gui"]["btn"]["retry"].hide()
 
     def remove_completed_from_download_list(self):
         with download_queue_lock:


### PR DESCRIPTION
Fix random SIGSEGV/double-free from cross-thread Qt widget access in workers