### PR TITLE
recover lost session + race conditional fixes

### DIFF
--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -414,9 +414,11 @@ def spotify_re_init_session(account, dead_session=None):
 def spotify_get_token(parsing_index):
     try:
         token = account_pool[parsing_index]["login"]["session"]
-    except (OSError, AttributeError):
+    except (OSError, AttributeError, KeyError):
+        token = None
+    if not token or isinstance(token, str):
         logger.info(
-            f"Failed to retreive token for {account_pool[parsing_index]['username']}, attempting to reinit session."
+            f"No valid session for {account_pool[parsing_index]['username']}, attempting to reinit session."
         )
         spotify_re_init_session(account_pool[parsing_index])
         token = account_pool[parsing_index]["login"]["session"]
@@ -1090,4 +1092,3 @@ def spotify_get_podcast_episode_ids(token, show_id):
         if episode:
             item_ids.append(episode["id"])
     return item_ids
-

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -30,6 +30,7 @@ _oauth_token_cache = {"access_token": None, "expires_at": 0, "client_id": None}
 _oauth_token_lock = threading.Lock()
 
 _session_reinit_lock = threading.Lock()
+_SESSION_REINIT_TIMEOUT = 30
 
 
 def spotify_get_oauth_token():
@@ -387,28 +388,42 @@ def spotify_re_init_session(account, dead_session=None):
             except Exception as e:
                 logger.debug(f"Failed to close old session: {e}")
             account["login"]["session"] = ""
-        try:
-            config = (
-                Session.Configuration.Builder()
-                .set_stored_credential_file(session_json_path)
-                .build()
+        result = {}
+
+        def _build():
+            try:
+                cfg = (
+                    Session.Configuration.Builder()
+                    .set_stored_credential_file(session_json_path)
+                    .build()
+                )
+                session = (
+                    Session.Builder(conf=cfg).stored_file(session_json_path).create()
+                )
+                result["session"] = session
+                result["account_type"] = session.get_user_attribute("type")
+            except Exception as e:
+                result["error"] = e
+
+        builder = threading.Thread(target=_build, daemon=True)
+        builder.start()
+        builder.join(timeout=_SESSION_REINIT_TIMEOUT)
+        if builder.is_alive():
+            logger.error(
+                "Session re-init timed out, network may be unavailable. Will retry later."
             )
-            logger.debug("Session config created")
-            session = (
-                Session.Builder(conf=config).stored_file(session_json_path).create()
-            )
-            logger.debug("Session re init done")
-            account["login"]["session_path"] = session_json_path
-            account["login"]["session"] = session
-            account["status"] = "active"
-            account["account_type"] = session.get_user_attribute("type")
-            bitrate = "160k"
-            account_type = session.get_user_attribute("type")
-            if account_type == "premium":
-                bitrate = "320k"
-            account["bitrate"] = bitrate
-        except Exception:
-            logger.error("Failed to re init session !")
+            return
+        session = result.get("session")
+        if session is None:
+            logger.error(f"Failed to re init session ! {result.get('error')}")
+            return
+        logger.debug("Session re init done")
+        account_type = result["account_type"]
+        account["login"]["session_path"] = session_json_path
+        account["login"]["session"] = session
+        account["status"] = "active"
+        account["account_type"] = account_type
+        account["bitrate"] = "320k" if account_type == "premium" else "160k"
 
 
 def spotify_get_token(parsing_index):

--- a/src/onthespot/api/spotify.py
+++ b/src/onthespot/api/spotify.py
@@ -29,6 +29,8 @@ BASE_URL = "https://api.spotify.com/v1"
 _oauth_token_cache = {"access_token": None, "expires_at": 0, "client_id": None}
 _oauth_token_lock = threading.Lock()
 
+_session_reinit_lock = threading.Lock()
+
 
 def spotify_get_oauth_token():
     """Return an OAuth access token via the Client-Credentials flow using the
@@ -371,30 +373,42 @@ def spotify_login_user(account):
         return False
 
 
-def spotify_re_init_session(account):
+def spotify_re_init_session(account, dead_session=None):
     session_json_path = os.path.join(
         cache_dir(), "sessions", f"ots_login_{account['uuid']}.json"
     )
-    try:
-        config = (
-            Session.Configuration.Builder()
-            .set_stored_credential_file(session_json_path)
-            .build()
-        )
-        logger.debug("Session config created")
-        session = Session.Builder(conf=config).stored_file(session_json_path).create()
-        logger.debug("Session re init done")
-        account["login"]["session_path"] = session_json_path
-        account["login"]["session"] = session
-        account["status"] = "active"
-        account["account_type"] = session.get_user_attribute("type")
-        bitrate = "160k"
-        account_type = session.get_user_attribute("type")
-        if account_type == "premium":
-            bitrate = "320k"
-        account["bitrate"] = bitrate
-    except:
-        logger.error("Failed to re init session !")
+    with _session_reinit_lock:
+        old_session = account.get("login", {}).get("session")
+        if dead_session is not None and old_session is not dead_session:
+            return
+        if old_session:
+            try:
+                old_session.close()
+            except Exception as e:
+                logger.debug(f"Failed to close old session: {e}")
+            account["login"]["session"] = ""
+        try:
+            config = (
+                Session.Configuration.Builder()
+                .set_stored_credential_file(session_json_path)
+                .build()
+            )
+            logger.debug("Session config created")
+            session = (
+                Session.Builder(conf=config).stored_file(session_json_path).create()
+            )
+            logger.debug("Session re init done")
+            account["login"]["session_path"] = session_json_path
+            account["login"]["session"] = session
+            account["status"] = "active"
+            account["account_type"] = session.get_user_attribute("type")
+            bitrate = "160k"
+            account_type = session.get_user_attribute("type")
+            if account_type == "premium":
+                bitrate = "320k"
+            account["bitrate"] = bitrate
+        except Exception:
+            logger.error("Failed to re init session !")
 
 
 def spotify_get_token(parsing_index):
@@ -1076,3 +1090,4 @@ def spotify_get_podcast_episode_ids(token, show_id):
         if episode:
             item_ids.append(episode["id"])
     return item_ids
+

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -83,6 +83,10 @@ logger = get_logger("downloader")
 _MAX_PATH_LENGTH = 260
 
 
+class TrackUnavailableError(Exception):
+    """Raised when a track has no playable version (not a connection issue)."""
+
+
 class RetryWorker(QObject):
     """Periodically resets failed download-queue items back to *Waiting*.
 
@@ -314,6 +318,13 @@ class DownloadWorker(QObject):
                         temp_path,
                         file_path,
                     )
+                except TrackUnavailableError:
+                    logger.error(f"Track is unavailable, track id '{item_id}'")
+                    item["item_status"] = ItemStatus.UNAVAILABLE
+                    if self.gui:
+                        self.progress.emit(item, self.tr("Unavailable"), 0)
+                    self._requeue_item(item)
+                    continue
                 except RuntimeError as exc:
                     logger.info(
                         f"Download failed (likely rate limited): {item}, Error: {exc}\n{traceback.format_exc()}"
@@ -623,7 +634,12 @@ class DownloadWorker(QObject):
             stream = token.content_feeder().load(
                 audio_key, VorbisOnlyAudioQuality(quality), False, None
             )
-        except (queue.Empty, RuntimeError) as exc:
+        except RuntimeError as exc:
+            if "alternative track" in str(exc).lower():
+                raise TrackUnavailableError(item_id) from exc
+            self._reinit_spotify_session(token)
+            raise RuntimeError(f"Spotify session connection lost: {exc}") from exc
+        except queue.Empty as exc:
             self._reinit_spotify_session(token)
             raise RuntimeError(f"Spotify session connection lost: {exc}") from exc
 
@@ -1245,4 +1261,3 @@ class DownloadWorker(QObject):
         return max(
             0, config.get("download_delay") + random.randint(-variance, variance)
         )
-

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -19,6 +19,7 @@ DownloadWorker
 """
 
 import os
+import queue
 import random
 import re
 import requests
@@ -591,6 +592,18 @@ class DownloadWorker(QObject):
 
         raise ValueError(f"No download handler for service '{service}'")
 
+    def _reinit_spotify_session(self, token):
+        from .api.spotify import spotify_re_init_session
+
+        for account in account_pool:
+            if (
+                account.get("service") == "spotify"
+                and account.get("login", {}).get("session") is token
+            ):
+                logger.info("Spotify session connection lost, re-initializing...")
+                spotify_re_init_session(account, dead_session=token)
+                return
+
     def _download_spotify(self, item, item_id, item_type, token, temp_path):
         default_format = ""
         temp_path += default_format
@@ -606,9 +619,14 @@ class DownloadWorker(QObject):
             quality = AudioQuality.VERY_HIGH
             bitrate = "320k"
 
-        stream = token.content_feeder().load(
-            audio_key, VorbisOnlyAudioQuality(quality), False, None
-        )
+        try:
+            stream = token.content_feeder().load(
+                audio_key, VorbisOnlyAudioQuality(quality), False, None
+            )
+        except (queue.Empty, RuntimeError) as exc:
+            self._reinit_spotify_session(token)
+            raise RuntimeError(f"Spotify session connection lost: {exc}") from exc
+
         total_size = stream.input_stream.size
         downloaded = 0
 
@@ -1227,3 +1245,4 @@ class DownloadWorker(QObject):
         return max(
             0, config.get("download_delay") + random.randint(-variance, variance)
         )
+


### PR DESCRIPTION
detect lost Spotify session during download and re-initialize it, close the old session on re-init so its socket/threads are freed, serialize re-init with a lock + double-check to avoid a concurrent re-init leaking a duplicate session