### PR TITLE
Fix Apple Music developer token extraction

### DIFF
--- a/src/onthespot/api/apple_music.py
+++ b/src/onthespot/api/apple_music.py
@@ -60,7 +60,7 @@ def apple_music_login_user(account):
         home_page = session.get("https://music.apple.com").text
         index_js_uri = re.search(r"/(assets/index-legacy[~-][^/\"]+.js)",home_page,).group(1)
         index_js_page = session.get(f"https://music.apple.com/{index_js_uri}").text
-        token = re.search('(?=eyJh)(.*?)(?=")', index_js_page).group(1)
+        token = re.search(r'nT="([^"]+)"', index_js_page).group(1)
         session.headers.update({"authorization": f"Bearer {token}"})
         session.params = {"l": 'en-US'}
 


### PR DESCRIPTION
## Summary

Apple Music login currently fails because the developer token extraction logic assumes the token is embedded directly in the Apple Music JavaScript bundle as a JWT beginning with `eyJh`.

Apple has changed how the bundle is structured. The developer token is now assigned to the `nT` variable, causing the existing regex to fail and resulting in:

```
Unknown Exception: 'NoneType' object has no attribute 'group'
```

## Changes

Replaced the outdated developer token extraction:

```python
re.search(r'(?=eyJh)(.*?)(?=")', index_js_page)
```

with extraction of the current token assignment:

```python
re.search(r'nT="([^"]+)"', index_js_page)
```

## Testing

* Verified against the current `music.apple.com` JavaScript bundle.
* Confirmed the bundle now contains:

```text
nT="eyJ..."
```

instead of an inline JWT matched by the previous regex.

After applying this change, Apple Music authentication succeeds using a valid `media-user-token`.
