### PR TITLE
Fix Title/By/cover regression in GUI download queue

### DIFF
--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -387,9 +387,14 @@ class DownloadWorker(QObject):
                 self._requeue_item(item)
 
             except Exception as exc:
-                logger.error(
-                    f"Unknown Exception: {exc}\nTraceback: {traceback.format_exc()}"
-                )
+                if item is not None and item["item_status"] == ItemStatus.CANCELLED:
+                    logger.info(
+                        f"Download cancelled by user for item '{item.get('item_id')}'"
+                    )
+                else:
+                    logger.error(
+                        f"Unknown Exception: {exc}\nTraceback: {traceback.format_exc()}"
+                    )
                 if item is not None:
                     if item["item_status"] != ItemStatus.CANCELLED:
                         item["item_status"] = ItemStatus.FAILED

--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -57,6 +57,7 @@ from ..api.generic import (
     generic_list_extractors,
 )
 from ..api.crunchyroll import crunchyroll_add_account, crunchyroll_get_episode_metadata
+from ..api.registry import get_metadata_function
 from ..downloader import DownloadWorker, RetryWorker
 from ..otsconfig import config, cache_dir
 from ..runtimedata import (
@@ -74,7 +75,7 @@ from ..runtimedata import (
 from .dl_progressbtn import DownloadActionsButtons
 from .settings import load_config, save_config
 from .thumb_listitem import LabelWithThumb
-from ..utils import is_latest_release, open_item, format_bytes
+from ..utils import get_cached_cover_bytes, is_latest_release, open_item, format_bytes
 from ..search import get_search_results
 
 logger = get_logger("gui.main_ui")
@@ -118,7 +119,7 @@ def create_failed_metadata(item, error_msg):
 
 
 class QueueWorker(QObject):
-    add_item_to_download_list = pyqtSignal(dict, dict)
+    add_item_to_download_list = pyqtSignal(dict, dict, bytes)
     error = pyqtSignal(str)
 
     def __init__(self):
@@ -136,13 +137,24 @@ class QueueWorker(QObject):
                     local_id = next(iter(pending))
                     with pending_lock:
                         item = pending.pop(local_id)
-
-                    self.add_item_to_download_list.emit(item, {})
-                    # Padding for 'GLib-ERROR : Creating pipes for GWakeup: Too many open files Trace/breakpoint trap'
-                    # when mass downloading cached responses with download queue thumbnails enabled.
-                    if config.get("show_download_thumbnails"):
-                        time.sleep(0.1)
-
+                    token = get_account_token(item["item_service"])
+                    metadata_fn = get_metadata_function(
+                        item["item_service"], item["item_type"]
+                    )
+                    item_metadata = metadata_fn(token, item["item_id"])
+                    if item_metadata:
+                        cover_bytes = (
+                            get_cached_cover_bytes(item_metadata.get("image_url"))
+                            or b""
+                        )
+                        self.add_item_to_download_list.emit(
+                            item, item_metadata, cover_bytes
+                        )
+                        # Padding for 'GLib-ERROR : Creating pipes for GWakeup: Too many open files Trace/breakpoint trap'
+                        # when mass downloading cached responses with download queue thumbnails enabled.
+                        if config.get("show_download_thumbnails"):
+                            time.sleep(0.1)
+                    continue
                 except Exception as e:
                     error_msg = f"Unknown Exception for {item}: {str(e)}"
                     logger.error(f"{error_msg}\nTraceback: {traceback.format_exc()}")
@@ -170,7 +182,7 @@ class QueueWorker(QObject):
 
                         # Create minimal metadata so item can be added to UI with "Failed" status
                         failed_metadata = create_failed_metadata(item, str(e))
-                        self.add_item_to_download_list.emit(item, failed_metadata)
+                        self.add_item_to_download_list.emit(item, failed_metadata, b"")
                     continue
             else:
                 time.sleep(0.2)
@@ -497,13 +509,7 @@ class MainWindow(QMainWindow):
             lambda: self.settings_scroll_area.verticalScrollBar().setValue(9999)
         )
 
-        self.clear_cache.clicked.connect(
-            lambda: (
-                shutil.rmtree(os.path.join(cache_dir(), "reqcache"))
-                and shutil.rmtree(os.path.join(cache_dir(), "logs"))
-                and self.show_popup_dialog(self.tr("Cache Cleared"))
-            )
-        )
+        self.clear_cache.clicked.connect(self.clear_app_cache)
         self.export_logs.clicked.connect(
             lambda: (
                 shutil.copy(
@@ -804,6 +810,12 @@ class MainWindow(QMainWindow):
         if new_path:
             temp_download_path.append(new_path)
 
+    def clear_app_cache(self):
+        shutil.rmtree(os.path.join(cache_dir(), "reqcache"))
+        shutil.rmtree(os.path.join(cache_dir(), "logs"))
+        shutil.rmtree(os.path.join(cache_dir(), "imgcache"), ignore_errors=True)
+        self.show_popup_dialog(self.tr("Cache Cleared"))
+
     def show_popup_dialog(self, txt, btn_hide=False, download=False):
         if download and config.get("disable_download_popups"):
             return
@@ -878,7 +890,11 @@ class MainWindow(QMainWindow):
             self.tbl_sessions.setCellWidget(rows, 6, remove_btn)
         logger.info("Accounts table was populated !")
 
-    def add_item_to_download_list(self, item, item_metadata):
+    def add_item_to_download_list(self, item, item_metadata, cover_bytes=b""):
+        # Check if this is a failed metadata fetch
+        is_metadata_fetch_failure = not item_metadata.get(
+            "is_playable", True
+        ) and "[FAILED]" in item_metadata.get("title", "")
 
         # Skip rendering QButtons if they are not in use
         copy_btn = None
@@ -944,7 +960,11 @@ class MainWindow(QMainWindow):
             delete_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
             delete_btn.hide()
 
-        item_by = "ND"
+        item_by = (
+            item_metadata.get("artists")
+            if item_metadata.get("artists")
+            else item_metadata.get("show_name")
+        )
 
         playlist_name = ""
         playlist_by = ""
@@ -953,9 +973,16 @@ class MainWindow(QMainWindow):
             playlist_name = item.get("playlist_name")
             playlist_by = item.get("playlist_by")
         elif item["parent_category"] in ("album", "show"):
-            item_category = f"{item['parent_category'].title()}"
+            parent_name = (
+                item_metadata.get("album_name")
+                if item_metadata.get("album_name")
+                else item_metadata.get("show_name")
+            )
+            item_category = f"{item['parent_category'].title()}: {parent_name}"
         else:
-            item_category = f"{item['parent_category'].title()}"
+            item_category = (
+                f"{item['parent_category'].title()}: {item_metadata.get('title')}"
+            )
 
         item_service = item["item_service"]
         service_label = QTableWidgetItem(str(item_service).replace("_", " ").title())
@@ -979,12 +1006,19 @@ class MainWindow(QMainWindow):
 
         rows = self.tbl_dl_progress.rowCount()
         self.tbl_dl_progress.insertRow(rows)
-        title = "ND"
+        if item_metadata.get("explicit"):
+            title = config.get("explicit_label") + " " + item_metadata.get("title")
+        else:
+            title = item_metadata.get("title")
 
-        item_label = QLabel(self.tbl_dl_progress)
-        item_label.setText(title)
-        item_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        item_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
+        if config.get("show_download_thumbnails") and cover_bytes:
+            self.tbl_dl_progress.setRowHeight(rows, config.get("thumbnail_size"))
+            item_label = LabelWithThumb(title, image_bytes=cover_bytes)
+        else:
+            item_label = QLabel(self.tbl_dl_progress)
+            item_label.setText(title)
+            item_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+            item_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
         item_label.setStyleSheet("background-color: transparent;")
 
         # Add To List
@@ -1027,6 +1061,16 @@ class MainWindow(QMainWindow):
                     },
                 },
             }
+
+            # If this was a metadata fetch failure, immediately set status to Failed
+            if is_metadata_fetch_failure:
+                download_queue[item["local_id"]]["item_status"] = "Failed"
+                status_label.setText(self.tr("Failed"))
+                pbar.setValue(0)
+                cancel_btn.hide()
+                retry_btn.show()
+                if copy_btn:
+                    copy_btn.show()
 
     def update_item_in_download_list(self, item, status, progress):
         self.statistics.setText(

--- a/src/onthespot/qt/thumb_listitem.py
+++ b/src/onthespot/qt/thumb_listitem.py
@@ -6,7 +6,7 @@ from ..otsconfig import config
 
 
 class LabelWithThumb(QWidget):
-    def __init__(self, label, thumb_url):
+    def __init__(self, label, thumb_url=None, image_bytes=None):
         super().__init__()
 
         self.aspect_ratio = config.get("thumbnail_size")
@@ -29,19 +29,35 @@ class LabelWithThumb(QWidget):
             self.aspect_ratio, self.aspect_ratio
         )  # Set fixed size for the image label
 
-        # Create QNetworkAccessManager
-        self.manager = QNetworkAccessManager(self)
-        request = QNetworkRequest(QUrl(thumb_url))
+        if image_bytes:
+            # Bytes already fetched (e.g. by a background worker) - load
+            # synchronously, no network round-trip needed.
+            pixmap = QPixmap()
+            pixmap.loadFromData(image_bytes)
+            self._set_pixmap(pixmap)
+        else:
+            # Create QNetworkAccessManager
+            self.manager = QNetworkAccessManager(self)
+            request = QNetworkRequest(QUrl(thumb_url))
 
-        # Connect the finished signal to the slot
-        self.manager.finished.connect(self.on_finished)
-        self.manager.get(request)  # Make the request
+            # Connect the finished signal to the slot
+            self.manager.finished.connect(self.on_finished)
+            self.manager.get(request)  # Make the request
 
         # Add both labels to the layout
         layout.addWidget(self.image_label)
         layout.addWidget(item_label)
 
         self.setLayout(layout)
+
+    def _set_pixmap(self, pixmap):
+        scaled_pixmap = pixmap.scaled(
+            self.aspect_ratio,
+            self.aspect_ratio,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        self.image_label.setPixmap(scaled_pixmap)
 
     def on_finished(self, reply: QNetworkReply):
         # This method is called when the network request is completed
@@ -52,16 +68,7 @@ class LabelWithThumb(QWidget):
             image_data = reply.readAll()
             pixmap = QPixmap()
             pixmap.loadFromData(image_data)
-
-            scaled_pixmap = pixmap.scaled(
-                self.aspect_ratio,
-                self.aspect_ratio,
-                Qt.AspectRatioMode.KeepAspectRatio,
-                Qt.TransformationMode.SmoothTransformation,
-            )
-            self.image_label.setPixmap(
-                scaled_pixmap
-            )  # Update the QLabel with the pixmap
+            self._set_pixmap(pixmap)
 
         # Mark request for deletion
         self.manager.deleteLater()

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -221,6 +221,30 @@ def make_call(
     raise requests.exceptions.RequestException(error_msg)
 
 
+def get_cached_cover_bytes(image_url):
+    """Return raw cover-art bytes for *image_url*, cached on disk (keyed by
+    URL MD5, mirroring ``make_call``'s ``reqcache``) so the same artwork is
+    never re-downloaded for every track of an album/show."""
+    if not image_url:
+        return None
+    cache_path = os.path.join(
+        config.get("_cache_dir"), "imgcache", md5(image_url.encode()).hexdigest()
+    )
+    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+    if os.path.isfile(cache_path):
+        with open(cache_path, "rb") as f:
+            return f.read()
+    try:
+        resp = requests.get(image_url, timeout=15)
+        resp.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to download cover image: {e}")
+        return None
+    with open(cache_path, "wb") as f:
+        f.write(resp.content)
+    return resp.content
+
+
 def format_local_id(item_id):
     """Return a unique local ID for *item_id* that does not clash with any
     existing entry in the download queue or pending dict."""
@@ -847,8 +871,11 @@ def set_music_thumbnail(filename, metadata):
     image_path = os.path.join(dirname, f"cover.{format}")
 
     logger.info("Fetching item thumbnail")
+    raw = get_cached_cover_bytes(metadata["image_url"])
+    if raw is None:
+        return
     try:
-        img = Image.open(BytesIO(requests.get(metadata["image_url"]).content))
+        img = Image.open(BytesIO(raw))
     except Exception as e:
         logger.error(f"Failed to download image: {e}")
         return

--- a/src/onthespot/web.py
+++ b/src/onthespot/web.py
@@ -425,6 +425,7 @@ def remove_account(uuid):
 def clear_cache():
     shutil.rmtree(os.path.join(cache_dir(), "reqcache"))
     shutil.rmtree(os.path.join(cache_dir(), "logs"))
+    shutil.rmtree(os.path.join(cache_dir(), "imgcache"), ignore_errors=True)
     return jsonify(success=True)
 
 


### PR DESCRIPTION
0cca5eb removed the metadata fetch from QueueWorker.run  to stop
duplicating Spotify api calls between the queue display and the actual download.
The fix just hardcoded title = "ND" and item_by = "ND" and never updated them
again, so every row in the download queue permanently shows "ND" for Title and By.
Downloads and tagging still worked fine, only the queue UI was broken. The queue
thumbnail got dropped in the same commit and never came back either.

Turns out the "duplicate API calls" concern doesn't really hold up: every metadata
function already goes through make_call(), which has cached every response to
disk since long before 0cca5eb. So a second fetch at download time is basically
free (checked this, no track's
metadata got fetched more than twice, second time always a cache hit).

Cover art was the one place with a real duplication, the gui thumbnail and the
tag embedding step each downloaded the same image raw, no cache, every single
track, even tracks from the same album.

## Changes
1. Restore Title/By/category/explicit-label in the queue, fetching metadata again
  in QueueWorker (now through get_metadata_function instead of the old
  globals()[...] lookup).
2. Add a small disk cache for cover art (imgcache/, keyed by image URL) so it's
  downloaded once per album/show instead of once per track, used by both the
  queue thumbnail and tag embedding.
3. Clear Cache (GUI + web) now also clears imgcache/. Also fixed a dormant bug
  in the GUI one where the old and chained lambda silently skipped clearing
  logs/ and never showed the "Cache Cleared" popup