### PR TITLE
fix: never drop queue items when metadata lookup fails

### DIFF
--- a/src/onthespot/qt/mainui.py
+++ b/src/onthespot/qt/mainui.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import threading
 import time
@@ -93,6 +94,36 @@ def is_permanent_failure(exception):
     return False
 
 
+# Metadata lookups are throttled by every service at a different threshold, so a
+# failed lookup is retried a few times before the item is given up on.
+MAX_METADATA_ATTEMPTS = 3
+
+# The status codes are only matched next to wording that identifies them as HTTP
+# statuses. Track ids are base62 and routinely contain digit runs such as "403",
+# so matching a bare number would mistake permanent failures for throttling.
+TRANSIENT_ERROR_PATTERN = re.compile(
+    r"(?:https?\s+)?error\s+4(?:03|29)\b"
+    r"|\b4(?:03|29)\s+(?:client\s+)?error\b"
+    r"|\bforbidden\b"
+    r"|too many requests"
+    r"|rate.?limit"
+    r"|timed out"
+    r"|\btimeout\b",
+    re.IGNORECASE,
+)
+
+
+def is_transient_failure(exception):
+    """Check if exception represents a temporary failure worth retrying.
+
+    Services throttle metadata lookups rather than refusing them outright:
+    Spotify answers with HTTP 429, and yt-dlp surfaces YouTube's throttling as
+    ``HTTP Error 403: Forbidden``. Items rejected this way are still valid and
+    only need to be asked for again later.
+    """
+    return bool(TRANSIENT_ERROR_PATTERN.search(str(exception)))
+
+
 def create_failed_metadata(item, error_msg):
     """Create minimal metadata for items that failed metadata fetch"""
     return {
@@ -130,9 +161,35 @@ class QueueWorker(QObject):
     def start(self):
         self.thread.start()
 
+    def report_failed(self, item, error_str):
+        """Show *item* in the download list as Failed and notify the user.
+
+        Items are removed from ``pending`` before their metadata is fetched, so
+        any path that neither queues an item nor reports it here loses it: it is
+        gone from ``pending``, never reaches ``download_queue``, and never
+        appears in the UI. Every failure therefore ends up in this method.
+        """
+        service = item["item_service"].replace("_", " ").title()
+        item_type = item["item_type"]
+
+        if "404" in error_str or "not found" in error_str.lower():
+            user_msg = f"Track not found: Could not load {item_type} from {service}. The item may have been removed or is unavailable in your region."
+        elif "Max retries" in error_str or "exhausted" in error_str:
+            user_msg = f"Failed to load {item_type} from {service} after multiple retries. The service may be experiencing issues."
+        else:
+            user_msg = f"Failed to load {item_type} from {service}: {error_str}"
+
+        self.error.emit(user_msg)
+
+        # Minimal metadata so the item can be listed with a "Failed" status.
+        failed_metadata = create_failed_metadata(item, error_str)
+        self.add_item_to_download_list.emit(item, failed_metadata, b"")
+
     def run(self):
         while self.is_running:
             if pending:
+                item = None
+                local_id = None
                 try:
                     local_id = next(iter(pending))
                     with pending_lock:
@@ -154,35 +211,59 @@ class QueueWorker(QObject):
                         # when mass downloading cached responses with download queue thumbnails enabled.
                         if config.get("show_download_thumbnails"):
                             time.sleep(0.1)
+                    else:
+                        # A falsy return is a failure too; reporting it keeps the
+                        # item visible instead of dropping it without a trace.
+                        logger.warning(
+                            f"No metadata returned for {item['item_id']}, marking as Failed."
+                        )
+                        self.report_failed(
+                            item, "The service returned no metadata for this item."
+                        )
                     continue
                 except Exception as e:
+                    if item is None:
+                        # Failed before an item was claimed, so there is nothing
+                        # to requeue or report.
+                        logger.error(
+                            f"Queue worker error before claiming an item: {str(e)}\n"
+                            f"Traceback: {traceback.format_exc()}"
+                        )
+                        time.sleep(0.2)
+                        continue
+
                     error_msg = f"Unknown Exception for {item}: {str(e)}"
                     logger.error(f"{error_msg}\nTraceback: {traceback.format_exc()}")
 
-                    # Check if this is a permanent failure (e.g., max retries exhausted)
-                    if is_permanent_failure(e):
+                    # Throttling is temporary — put the item back and try again
+                    # later rather than failing it.
+                    attempts = item.get("metadata_attempts", 0) + 1
+                    if is_transient_failure(e) and not is_permanent_failure(e):
+                        if attempts < MAX_METADATA_ATTEMPTS:
+                            item["metadata_attempts"] = attempts
+                            with pending_lock:
+                                pending[local_id] = item
+                            logger.warning(
+                                f"Transient failure for {item['item_id']} "
+                                f"(attempt {attempts}/{MAX_METADATA_ATTEMPTS}), requeueing."
+                            )
+                            # Re-inserting appends to ``pending``, so other items
+                            # are served first; the pause covers a queue holding
+                            # only this item.
+                            time.sleep(max(1, int(config.get("download_delay") or 1)))
+                            continue
+                        logger.warning(
+                            f"Transient failure for {item['item_id']} persisted after "
+                            f"{MAX_METADATA_ATTEMPTS} attempts, marking as Failed."
+                        )
+                    elif is_permanent_failure(e):
                         logger.warning(
                             f"Permanent failure detected for {item['item_id']}, will not retry. Adding to download list as Failed."
                         )
 
-                        # Create user-friendly error message
-                        error_str = str(e)
-                        service = item["item_service"].replace("_", " ").title()
-                        item_type = item["item_type"]
-
-                        if "404" in error_str or "not found" in error_str.lower():
-                            user_msg = f"Track not found: Could not load {item_type} from {service}. The item may have been removed or is unavailable in your region."
-                        elif "Max retries" in error_str or "exhausted" in error_str:
-                            user_msg = f"Failed to load {item_type} from {service} after multiple retries. The service may be experiencing issues."
-                        else:
-                            user_msg = f"Failed to load {item_type} from {service}: {error_str}"
-
-                        # Emit error to UI
-                        self.error.emit(user_msg)
-
-                        # Create minimal metadata so item can be added to UI with "Failed" status
-                        failed_metadata = create_failed_metadata(item, str(e))
-                        self.add_item_to_download_list.emit(item, failed_metadata, b"")
+                    # Anything still here failed for a reason we cannot classify.
+                    # Report it rather than dropping it.
+                    self.report_failed(item, str(e))
                     continue
             else:
                 time.sleep(0.2)


### PR DESCRIPTION
### Problem

`QueueWorker.run()` removes an item from `pending` **before** fetching its metadata:

```python
local_id = next(iter(pending))
with pending_lock:
    item = pending.pop(local_id)
...
item_metadata = metadata_fn(token, item["item_id"])
```

If the lookup then raises, the item is only re-surfaced when `is_permanent_failure()` matches. Every other exception fell through to a bare `continue`, at which point the item was:

- already removed from `pending`,
- never added to `download_queue`,
- never rendered in the UI, and
- never marked Failed.

It simply disappeared, with no error shown and nothing left in the queue to retry.

`is_permanent_failure()` only matches `"Max retries"`, `"exhausted"`, `"404"`, `"not found"` and `"Item ID is None"`. yt-dlp reports YouTube throttling as `HTTP Error 403: Forbidden`, which matches none of them — so on a large YouTube playlist every throttled track was silently lost. That is exactly the report in #355 (~500 of 800 items missing, and explicitly *not* listed as failed), and it matches the maintainer comment there that items "fail with 403 but they do not report back the status". It is also consistent with #301, where downloads never appear at all.

Two smaller paths lost items the same way:

- `if item_metadata:` had no `else`, so a falsy return was dropped without a trace.
- If the exception fired before `item` was assigned (e.g. the queue was drained concurrently), the handler's own `f"Unknown Exception for {item}"` raised `NameError`, killing the worker thread for the rest of the session.

Worth noting the WebUI path (`web.py`) re-queues on exception and so never loses items — only the Qt GUI does.

### Change

The invariant is now: **every item is either queued, re-queued, or shown as Failed — never dropped.**

- **`is_transient_failure()`** — new classifier for throttling and timeouts. Matching items are put back into `pending` and retried up to `MAX_METADATA_ATTEMPTS` (3), pausing by the existing `download_delay` between attempts. Re-inserting appends to `pending`, so other items are served first rather than hot-looping on one.
- **`report_failed()`** — extracted from the existing permanent-failure branch and now called for *any* failure that isn't transient, including ones that can't be classified. Defaulting to "surface it" rather than "swallow it".
- Falsy metadata returns are reported instead of ignored.
- Guarded the pre-assignment exception case that previously killed the worker thread.

User-facing error message wording is unchanged.

One deliberate detail: the status codes are only matched next to HTTP wording (`error 403`, `403 client error`) rather than as bare numbers. Track ids are base62 and routinely contain digit runs like `403`, so a naive substring match would classify permanent failures as throttling. I checked this against ids such as `4034aBcDeFgHiJkLmNoPqR`.

### Testing

Being straightforward about this: **I have not run the Qt GUI end-to-end against a real 800-item playlist.** What was verified:

- The module compiles, and the changed control flow was checked by hand for every exit path out of the loop body.
- The classifier was exercised in isolation against real error strings from these issues — yt-dlp's `HTTP Error 403: Forbidden`, `429 Client Error: Too Many Requests`, `Read timed out`, `404 Client Error`, `Max retries ... exhausted` — plus the base62 false-positive cases above. All behaved as intended.

A maintainer with an account and a large playlist should confirm the requeue path under real throttling before this is trusted. If you would prefer the retry loop gated behind a config key rather than always on, happy to change that.

### Related

Fixes #355.
Likely also fixes #301, though that report has no logs so I cannot confirm it is the same path.

Not addressed here, but adjacent and worth separate PRs:

- `is_permanent_failure()` classifies a transient 429 as permanent, because `make_call` flattens every failure into a formatted string containing `"exhausted"`. That appears to be the cause of #309 ("max retries exhausted even after waiting several days") — a rate limit gets latched forever. The real fix is propagating HTTP status codes instead of substring-matching messages, which touches `utils.make_call` and four call sites.
- `cli.py:122` calls `parsingworker`, but only the class `ParsingWorker` exists — the CLI raises `NameError` on startup on this branch.

---

*Disclosure: this change was written with automated analysis assistance. The root cause was traced by reading the code paths above and the classifier behaviour was verified as described; the end-to-end GUI run was not performed.*
