### PR TITLE
fix: [LEGACY] correct deezer temp path, and follow fallbacks fixes #96 

### DIFF
--- a/src/onthespot/api/deezer.py
+++ b/src/onthespot/api/deezer.py
@@ -1,5 +1,3 @@
-import html.parser
-import json
 import random
 import re
 import requests
@@ -13,25 +11,6 @@ from ..utils import conv_list_format, make_call
 
 logger = get_logger("api.deezer")
 BASE_URL = "https://api.deezer.com/"
-
-
-class ScriptExtractor(html.parser.HTMLParser):
-    """extract <script> tag contents from a html page"""
-
-    def __init__(self):
-        html.parser.HTMLParser.__init__(self)
-        self.scripts = []
-        self.curtag = None
-
-    def handle_starttag(self, tag, attrs):
-        self.curtag = tag.lower()
-
-    def handle_data(self, data):
-        if self.curtag == "script":
-            self.scripts.append(data)
-
-    def handle_endtag(self, tag):
-        self.curtag = None
 
 
 def deezer_add_account(arl):
@@ -79,8 +58,7 @@ def deezer_get_playlist_data(_, playlist_id):
         track_ids.append(track.get("id"))
     return playlist_name, playlist_by, track_ids
 
-
-def deezer_get_track_metadata(_, item_id):
+def deezer_get_track_metadata(token, item_id):
     logger.info(f"Get track info for: '{item_id}'")
 
     track_data = make_call(f"{BASE_URL}/track/{item_id}")
@@ -136,31 +114,34 @@ def deezer_get_track_metadata(_, item_id):
     info["album_artists"] = album_data.get("artist", {}).get("name")
     info["album_name"] = track_data.get("album", {}).get("title")
     info["album_type"] = album_data.get("record_type")
-    info["is_playable"] = track_data.get("readable")
+    info["is_playable"] = bool(track_data.get("readable"))
+    if not info["is_playable"]:
+        fallback = get_song_info_from_deezer_website(token, item_id)
+        info["is_playable"] = bool(
+            fallback
+            and str(fallback.get("SNG_ID")) != str(item_id)
+            and fallback.get("TRACK_TOKEN")
+        )
     info["item_id"] = track_data.get("id")
 
     return info
 
 
 def get_song_info_from_deezer_website(token, track_id):
-    url = f"https://www.deezer.com/us/track/{track_id}"
-    session = token["session"]
-    resp = session.get(url)
-    if resp.status_code == 404:
-        logger.info(f"Received 404 while fetching MD5_ORIGIN, {url}")
-    if "MD5_ORIGIN" not in resp.text:
-        logger.info(f"Deezer MD5_ORIGIN missing for {url}")
-    parser = ScriptExtractor()
-    parser.feed(resp.text)
-    parser.close()
-
-    songs = []
-    for script in parser.scripts:
-        regex = re.search(r'{"DATA":.*', script)
-        if regex:
-            DZR_APP_STATE = json.loads(regex.group())
-            songs.append(DZR_APP_STATE["DATA"])
-    return songs[0]
+    params = {
+        "api_version": "1.0",
+        "api_token": token["api_token"],
+        "input": "3",
+        "method": "song.getData",
+    }
+    song_data = token["session"].post(
+        "https://www.deezer.com/ajax/gw-light.php",
+        params=params,
+        json={"SNG_ID": str(track_id)},
+    ).json().get("results")
+    if not isinstance(song_data, dict):
+        return None
+    return song_data.get("FALLBACK") or song_data
 
 
 def md5hex(data):
@@ -317,6 +298,7 @@ def deezer_login_user(account):
                 "bitrate": bitrate,
                 "login": {
                     "arl": arl,
+                    "api_token": user_data["results"]["checkForm"],
                     "license_token": user_data["results"]["USER"]["OPTIONS"][
                         "license_token"
                     ],

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -699,8 +699,6 @@ class DownloadWorker(QObject):
         elif int(song.get("FILESIZE_MP3_256", 0)) > 0:
             song_quality, song_format, bitrate = 5, "MP3_256", "256k"
 
-        temp_path += default_format
-
         headers = {
             "Origin": "https://www.deezer.com",
             "Accept-Encoding": "utf-8",


### PR DESCRIPTION
Current legacy version has 2 deezer-related issues.

* The first one is a simple missmatch between effective and expected directories used by the downloader. This resulted in every download attempt ending with FAILED statuses.

* The second one was described in #96. For certain tracks, the download would always fail with a "UNAVAILABLE" status. It is seems especially common when it comes to compilation albums or remasters.
It seems the issue is for tracks for which deezer has "fallbacks". When using the regular app, behind the scene deezer retrieves the audio from another track, with a different id.
The previous downloader direcly requested the public webpage of the track, and parsed the result to retrieve its content. Such page does not exist for tracks with a fallback, which resulted in this "UNAVAILABLE" status
Instead, I directly query the song.getData gateway, using the token retrieved during the first authentication. In case of a track with a fallback, the server's response contains all required information to retrieve the actual audio. 
The file is saved with the metadata from the pre-fallback track. This is to keep consistency with what the user can see on their deezer account (and because that is the behaviour I wanted for my personal patch x) ). But I guess it could be changed, or added as a config setting if you see any reason to.

---
If I understood properly, the "search-filter-fix" branch is the one currently used for the legacy version. If I am wrong, let me know or feel free to move this.