### PR TITLE
feat(runtimedata): add __contains__ and __iter__ to ThreadSafeDeque

### DIFF
--- a/api/src/onthespot/runtimedata.py
+++ b/api/src/onthespot/runtimedata.py
@@ -114,6 +114,19 @@ class ThreadSafeDeque:
         with self._lock:
             return len(self._deque)
 
+    def __contains__(self, item):
+        # Tests membership without copying the whole queue, and stops at the
+        # first match. `item in queue.get_items()` builds a full list first.
+        with self._lock:
+            return item in self._deque
+
+    def __iter__(self):
+        # Iterates a snapshot taken under the lock, so another thread adding or
+        # removing entries mid-loop cannot invalidate the iterator.
+        with self._lock:
+            items = list(self._deque)
+        return iter(items)
+
 
 #: Pool of authenticated service accounts added by :class:`AccountPoolLoader`.
 account_pool: list = []


### PR DESCRIPTION
picking up the "Deque not having the internal methods for iter ecc" item from your list in #354.

### what this is

`ThreadSafeDeque` defines `__len__` but not `__contains__` or `__iter__`, so `x in queue` and `for x in queue` both raise `TypeError`. Callers have to use `get_items()` instead, which copies the entire queue under the lock just to answer a single membership question.

this adds both:

- `__contains__` tests under the lock without building a list, and short circuits on the first match
- `__iter__` takes a snapshot under the lock and iterates that, so another thread appending or popping mid loop can't invalidate the iterator

### what this is not

worth being clear: **this does not fix a bug on `fastapi-dev` today.** every current call site already goes through `get_items()` correctly, `api/spotify.py:192` and `main.py:266` included. nothing is broken right now.

it matters for what comes next. you mentioned wanting to iterate `pending` directly instead of the queue_preloaded dance, and migrating the other queues onto this class. both need these methods to exist first. and #354 as it stands introduces `item_id not in pending` in the mirror worker, which throws `TypeError` today and would silently kill that thread, so having this landed first means that merge doesn't bring the crash with it.

no call sites changed here, so it's purely additive and won't conflict with the websocket queue migration you're testing. simplifying the existing `get_items()` callers can happen after, whenever it's convenient.

`__getitem__` left out on purpose, nothing needs indexed access into a queue and it mostly invites racy read then index patterns.

### checking

no test infra on this branch so nothing added, didn't want to drag pytest config into it. i pulled the class out on its own and exercised it: membership hit and miss, `list()`, for loop, `empty()` still fine, an iterator taken before a concurrent put/pop stays consistent, and no self deadlock given the lock isn't reentrant.
