### PR TITLE
docs: update repository urls after the org move

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-OnTheSpot is an open-source project licensed under [GPL-2.0](https://github.com/justin025/onthespot/blob/main/LICENSE) and its code is distributed for educational and personal use only.
+OnTheSpot is an open-source project licensed under [GPL-2.0](https://github.com/ots-downloader/onthespot/blob/main/LICENSE) and its code is distributed for educational and personal use only.
 
 By using this software, you agree to the following terms:
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@
       <br />
       <a href="https://discord.gg/GCQwRBFPk9">Join Discord</a>
       ·
-      <a href="https://github.com/justin025/OnTheSpot/issues/new?assignees=&labels=bug&projects=&template=bug-report.yml">Report Bug</a>
+      <a href="https://github.com/ots-downloader/onthespot/issues/new?assignees=&labels=bug&projects=&template=bug-report.yml">Report Bug</a>
       ·
-      <a href="https://github.com/justin025/OnTheSpot/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml">Request Feature</a>
+      <a href="https://github.com/ots-downloader/onthespot/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml">Request Feature</a>
    </p>
    <br>
 </div>
 
-An easy to use music downloader written in Python. OnTheSpot has support for various music services and, unlike similar projects, downloaded files and metadata are sourced directly from the service of your choosing. The app includes a GUI, CLI, and Web UI frontend. To get started download the app [here](https://github.com/justin025/onthespot/releases/latest) or run the command below.
+An easy to use music downloader written in Python. OnTheSpot has support for various music services and, unlike similar projects, downloaded files and metadata are sourced directly from the service of your choosing. The app includes a GUI, CLI, and Web UI frontend. To get started download the app [here](https://github.com/ots-downloader/onthespot/releases/latest) or run the command below.
 ```bash
-python3 -m pip install git+https://github.com/justin025/onthespot
+python3 -m pip install git+https://github.com/ots-downloader/onthespot
 ```
 For more further documentation, please see the following:
 
@@ -45,12 +45,12 @@ For more further documentation, please see the following:
 
 If you have any questions or run into issues while using OnTheSpot, feel free to ask for assistance by:
 
-- [**Opening an Issue**](https://github.com/justin025/onthespot/issues)
+- [**Opening an Issue**](https://github.com/ots-downloader/onthespot/issues)
 - [**Joining Our Discord**](https://discord.gg/GCQwRBFPk9)
 
 ## Contributing
 
-If you encounter bugs, have suggestions, or would like to help translate the app to your native language don't hesitate to [**open an issue**](https://github.com/justin025/onthespot/issues) or submit a pull request.
+If you encounter bugs, have suggestions, or would like to help translate the app to your native language don't hesitate to [**open an issue**](https://github.com/ots-downloader/onthespot/issues) or submit a pull request.
 
 ## Disclaimer
 
@@ -61,14 +61,14 @@ OnTheSpot contributors are not responsible for any misuse of the program or sour
 For further information, please see the following [**disclaimer**](DISCLAIMER.md).
 
 <!-- Issues Badge -->
-[issues-shield]: https://img.shields.io/github/issues/justin025/onthespot?style=flat&label=Issues&labelColor=001224&color=1DB954
-[issues-url]: https://github.com/justin025/onthespot/issues
+[issues-shield]: https://img.shields.io/github/issues/ots-downloader/onthespot?style=flat&label=Issues&labelColor=001224&color=1DB954
+[issues-url]: https://github.com/ots-downloader/onthespot/issues
 <!-- Stars Badge -->
-[stars-shield]: https://img.shields.io/github/stars/justin025/onthespot?style=flat&label=Stars&labelColor=001224&color=1DB954
-[stars-url]: https://github.com/justin025/onthespot/stargazers
+[stars-shield]: https://img.shields.io/github/stars/ots-downloader/onthespot?style=flat&label=Stars&labelColor=001224&color=1DB954
+[stars-url]: https://github.com/ots-downloader/onthespot/stargazers
 <!-- Downloads Badge -->
-[downloads-shield]: https://img.shields.io/github/downloads/justin025/onthespot/total.svg?style=flat&label=Downloads&labelColor=001224&color=1DB954
-[downloads-url]: https://github.com/justin025/onthespot/releases/
+[downloads-shield]: https://img.shields.io/github/downloads/ots-downloader/onthespot/total.svg?style=flat&label=Downloads&labelColor=001224&color=1DB954
+[downloads-url]: https://github.com/ots-downloader/onthespot/releases/
 <!-- License Badge -->
-[license-shield]: https://img.shields.io/github/license/justin025/onthespot?style=flat&label=License&labelColor=001224&color=1DB954
-[license-url]: https://github.com/justin025/onthespot/blob/main/LICENSE
+[license-shield]: https://img.shields.io/github/license/ots-downloader/onthespot?style=flat&label=License&labelColor=001224&color=1DB954
+[license-url]: https://github.com/ots-downloader/onthespot/blob/main/LICENSE

--- a/distros/arch/PKGBUILD
+++ b/distros/arch/PKGBUILD
@@ -4,14 +4,14 @@ _branch="master"
 pkgrel=1
 pkgdesc="Qt based music downloader written in python"
 arch=('any')
-url="https://github.com/justin025/onthespot"
+url="https://github.com/ots-downloader/onthespot"
 license=('GPLv2')
 depends=('ffmpeg' 'python-requests' 'python_urllib3' 'python-musictag' 'python-mutagen' 'python-pyqt6' 'python-pillow' 'python-librespot' 'yt-dlp' 'python-flask' 'python-flask-login' 'python-m3u8' 'python-pywidevine')
 conflicts=('onthespot')
 provides=('onthespot')
 makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
 optdepends=()
-source=("https://github.com/justin025/onthespot/archive/refs/heads/$_branch.zip")
+source=("https://github.com/ots-downloader/onthespot/archive/refs/heads/$_branch.zip")
 sha256sums=(SKIP)
 
 build() {

--- a/distros/gentoo/media-sound/onthespot/metadata.xml
+++ b/distros/gentoo/media-sound/onthespot/metadata.xml
@@ -11,6 +11,6 @@
                 </flag>
         </use>
         <upstream>
-                <remote-id type="github">justin025/onthespot</remote-id>
+                <remote-id type="github">ots-downloader/onthespot</remote-id>
         </upstream>
 </pkgmetadata>

--- a/distros/gentoo/media-sound/onthespot/onthespot-1.1.4.ebuild
+++ b/distros/gentoo/media-sound/onthespot/onthespot-1.1.4.ebuild
@@ -10,15 +10,15 @@ inherit distutils-r1 desktop xdg
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/justin025/onthespot.git"
+	EGIT_REPO_URI="https://github.com/ots-downloader/onthespot.git"
 else
-	SRC_URI="https://github.com/justin025/onthespot/archive/refs/tags/v${PV}.tar.gz
+	SRC_URI="https://github.com/ots-downloader/onthespot/archive/refs/tags/v${PV}.tar.gz
 			 -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 
 DESCRIPTION="qt based music downloader written in python"
-HOMEPAGE="https://github.com/justin025/onthespot"
+HOMEPAGE="https://github.com/ots-downloader/onthespot"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/distros/gentoo/media-sound/onthespot/onthespot-9999.ebuild
+++ b/distros/gentoo/media-sound/onthespot/onthespot-9999.ebuild
@@ -10,15 +10,15 @@ inherit distutils-r1 desktop xdg
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/justin025/onthespot.git"
+	EGIT_REPO_URI="https://github.com/ots-downloader/onthespot.git"
 else
-	SRC_URI="https://github.com/justin025/onthespot/archive/refs/tags/v${PV}.tar.gz
+	SRC_URI="https://github.com/ots-downloader/onthespot/archive/refs/tags/v${PV}.tar.gz
 			 -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 fi
 
 DESCRIPTION="qt based music downloader written in python"
-HOMEPAGE="https://github.com/justin025/onthespot"
+HOMEPAGE="https://github.com/ots-downloader/onthespot"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,7 +6,7 @@ This is the easiest way to get started.
 
 1. **Download the Latest Release**
 
-   - Visit our [GitHub Releases Page](https://github.com/justin025/onthespot/releases).
+   - Visit our [GitHub Releases Page](https://github.com/ots-downloader/onthespot/releases).
    - Look for the latest version suitable for your operating system:
      - **Windows Users**: Download the `.exe` file.
      - **MacOS Users**: Download the `.dmg` file associated with your mac (x86_64 for intel, arm64 for apple silicone).
@@ -37,7 +37,7 @@ If you prefer to build OnTheSpot yourself, follow these steps.
    - The source code can be downloaded through github or through the commands below:
 
      ```bash
-     git clone https://github.com/justin025/onthespot
+     git clone https://github.com/ots-downloader/onthespot
      cd onthespot
      ```
 
@@ -61,7 +61,7 @@ source venv/bin/activate
 ```
 Next you can download and run the app by installing via pip:
 ```bash
-python3 -m pip install git+https://github.com/justin025/onthespot --force
+python3 -m pip install git+https://github.com/ots-downloader/onthespot --force
 
 onthespot-cli #cli
 onthespot-gui #gui
@@ -69,7 +69,7 @@ onthespot-web #web ui
 ```
 Alternatively you can run the app from source following the commands listed below:
 ```bash
-git clone https://github.com/justin025/onthespot
+git clone https://github.com/ots-downloader/onthespot
 
 cd onthespot/src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 author = Justin Donofrio
 author_email = justin026@protonmail.com
-url = https://github.com/justin025/onthespot
+url = https://github.com/ots-downloader/onthespot
 keywords = music, downloader, audio, onthespot
 license = GPL-2.0 License
 

--- a/src/onthespot/resources/web/about.html
+++ b/src/onthespot/resources/web/about.html
@@ -10,7 +10,7 @@
     <body>
         <div class="header">
             <ul>
-                <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
+                <li class="hide-on-mobile"><a href="https://github.com/ots-downloader/onthespot/" target="_blank">OnTheSpot</a></li>
                 <li><a href="/search">Search</a></li>
                 <li><a href="/download_queue">Downloads</a></li>
                 <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/download_queue.html
+++ b/src/onthespot/resources/web/download_queue.html
@@ -11,7 +11,7 @@
 <body>
     <div class="header">
         <ul>
-            <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
+            <li class="hide-on-mobile"><a href="https://github.com/ots-downloader/onthespot/" target="_blank">OnTheSpot</a></li>
             <li><a href="/search">Search</a></li>
             <li><a class="active" href="/download_queue">Downloads</a></li>
             <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/search.html
+++ b/src/onthespot/resources/web/search.html
@@ -11,7 +11,7 @@
     <body>
         <div class="header">
             <ul>
-                <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
+                <li class="hide-on-mobile"><a href="https://github.com/ots-downloader/onthespot/" target="_blank">OnTheSpot</a></li>
                 <li><a class="active" href="/search">Search</a></li>
                 <li><a href="/download_queue">Downloads</a></li>
                 <li><a href="/settings">Settings</a></li>

--- a/src/onthespot/resources/web/settings.html
+++ b/src/onthespot/resources/web/settings.html
@@ -11,7 +11,7 @@
     <body>
         <div class="header">
             <ul>
-                <li class="hide-on-mobile"><a href="https://github.com/justin025/onthespot/" target="_blank">OnTheSpot</a></li>
+                <li class="hide-on-mobile"><a href="https://github.com/ots-downloader/onthespot/" target="_blank">OnTheSpot</a></li>
                 <li><a href="/search">Search</a></li>
                 <li><a href="/download_queue">Downloads</a></li>
                 <li><a class="active" href="/settings">Settings</a></li>

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -78,7 +78,7 @@ def format_local_id(item_id):
 
 
 def is_latest_release():
-    url = "https://api.github.com/repos/justin025/onthespot/releases/latest"
+    url = "https://api.github.com/repos/ots-downloader/onthespot/releases/latest"
     response = requests.get(url)
     if response.status_code == 200:
         current_version = config.get("version").replace('v', '').replace('.', '')
@@ -333,7 +333,7 @@ def embed_metadata(item, metadata):
         # https://wiki.multimedia.cx/index.php?title=FFmpeg_Metadata
 
         if config.get("embed_branding"):
-            branding = "Downloaded by OnTheSpot, https://github.com/justin025/onthespot"
+            branding = "Downloaded by OnTheSpot, https://github.com/ots-downloader/onthespot"
             if filetype == '.mp3':
                 # Incorrectly embedded to TXXX:TCMP, patch sent upstream
                 command += ['-metadata', 'COMM={}'.format(branding)]


### PR DESCRIPTION
Refs #371

## What

Replaces the stale `justin025/onthespot` urls on `master` with `ots-downloader/onthespot`.

## Why

The old urls still redirect, so nothing is broken today. They only bite if that name is ever recreated by someone else, and they read as stale to anyone browsing the repo. The distro packaging urls are the ones package managers actually fetch from, so those are the most worth having correct.

This covers the `master` half of #371. The `docs/INSTALLATION.md` fork clone url that issue calls out as the one that actually matters lives on the #354 branch, not here, and @magedhennawy already has a branch for it — leaving that one alone.

## How

Updated:

- `README.md` — bug report / feature request template links, pip install, releases link, issues links, and all four shields
- `DISCLAIMER.md` — license link
- `docs/INSTALLATION.md` — releases link, two `git clone` urls, pip install
- `setup.cfg` — project url
- `distros/arch/PKGBUILD` — `url` and `source`
- `distros/gentoo/**` — `HOMEPAGE`, `EGIT_REPO_URI`, `SRC_URI` on both ebuilds, and the `remote-id` in `metadata.xml`
- `src/onthespot/resources/web/*.html` — the OnTheSpot link in the four page headers
- `src/onthespot/utils.py` — the release-check api url and the branding string written into downloaded files

Deliberately left alone:

- `distros/fedora/onthespot.spec:51` — changelog entry, historical record
- `src/onthespot/api/tidal.py` — the issue citation for the shim, still valid
- `src/onthespot/resources/translations/*.ts` — cosmetic url, not worth redoing translations
- **`src/onthespot/qt/mainui.py:307`** — not listed in the issue, but this is the `tr()` source string that generates those `.ts` entries. Changing it here would invalidate the same six translations the issue asks to leave alone, so it stays until someone is doing a translation pass anyway.
- `justin025.github.io` donate links and `justin025/librespot-python` — neither of those moved

No reformatting, no unrelated changes. 35 lines across 13 files.

## Verification

Every replaced url resolves:

```
$ for u in \
    "https://github.com/ots-downloader/onthespot" \
    "https://api.github.com/repos/ots-downloader/onthespot/releases/latest" \
    "https://github.com/ots-downloader/onthespot/issues/new?template=bug-report.yml"; do
    printf "%s %s\n" "$(curl -s -o /dev/null -w '%{http_code}' -L "$u")" "$u"
  done
200 https://github.com/ots-downloader/onthespot
200 https://api.github.com/repos/ots-downloader/onthespot/releases/latest
200 https://github.com/ots-downloader/onthespot/issues/new?template=bug-report.yml
```

`utils.py` still parses:

```
$ python -c "import ast; ast.parse(open('src/onthespot/utils.py',encoding='utf-8').read()); print('ok')"
ok
```

And no unintended `justin025` references remain — the only ones left are the five deliberate ones listed above.

Happy to split the distro packaging files into their own PR, or to drop the `utils.py` change if you'd rather keep this docs-only.
