### PR TITLE
fix(appimage): resolve the python runtime from its rolling release tag

### DIFF
--- a/scripts/build_appimage.sh
+++ b/scripts/build_appimage.sh
@@ -11,10 +11,23 @@ echo " => Fetch Dependencies"
 mkdir build
 cd build
 
-curl -L -o appimagetool-x86_64.AppImage https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+curl -fL -o appimagetool-x86_64.AppImage https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage || exit 1
 chmod +x appimagetool-x86_64.AppImage
 
-curl -L -o python.AppImage https://github.com/niess/python-appimage/releases/download/python3.12/python3.12.12-cp312-cp312-manylinux2014_x86_64.AppImage
+# python-appimage publishes to a rolling "python3.12" tag and deletes the old
+# asset on every patch bump, so a pinned patch version 404s a few weeks later.
+# Ask the release for whichever 3.12.x it currently carries.
+PYTHON_APPIMAGE_URL=$(curl -fsSL https://api.github.com/repos/niess/python-appimage/releases/tags/python3.12 \
+    | grep -o 'https://github.com/niess/python-appimage/releases/download/[^"]*-cp312-cp312-manylinux2014_x86_64\.AppImage' \
+    | head -n 1)
+
+if [ -z "$PYTHON_APPIMAGE_URL" ]; then
+    echo "Could not find a cp312 manylinux2014 x86_64 asset on the python3.12 release" >&2
+    exit 1
+fi
+
+echo " => Using $PYTHON_APPIMAGE_URL"
+curl -fL -o python.AppImage "$PYTHON_APPIMAGE_URL" || exit 1
 chmod +x python.AppImage
 
 ./python.AppImage --appimage-extract


### PR DESCRIPTION
`appimage-x86_64-build` is the only failing job in Release Builder, and it has failed on both **v1.8.0** and **v1.8.1**. Neither release shipped a Linux AppImage — v1.8.1's assets are two `.dmg`, one `.exe` and one `.tar.gz`.

@moddroid94 mentioned this in passing on #371 ("right now the appimage build fails so idk if that really matters"), and there is no issue open for it, so I went and looked.

## Cause

`scripts/build_appimage.sh` pinned an exact patch version of the Python runtime:

```
https://github.com/niess/python-appimage/releases/download/python3.12/python3.12.12-cp312-cp312-manylinux2014_x86_64.AppImage
```

`python3.12` upstream is a rolling tag. python-appimage replaces the asset on every patch bump rather than cutting a new tag, so a pinned patch version stops existing a few weeks later. The tag currently carries `3.12.13`, and that will move too.

The confusing part is why the log looks unrelated to a download. The script used `curl -L`, not `curl -fL`:

| | exit | result |
|---|---|---|
| `curl -sL` | 0 | writes the 9-byte body `Not Found` into `python.AppImage` |
| `curl -sfL` | 22 | no file written |

So `chmod +x` marked a text file executable, `./python.AppImage` ran it, and bash reported:

```
./python.AppImage: line 1: Not: command not found
mv: cannot stat 'squashfs-root': No such file or directory
```

Every later error — the `AppRun` failures, the `cp` cascade, the missing `.desktop` — is downstream of that one silent write. The script then **exits 0** despite having built nothing, which is why the job only goes red much later at the upload step with `ENOENT: no such file or directory, stat 'dist/OnTheSpot-x86_64.AppImage'`.

## Change

- Ask the `python3.12` release which `3.12.x` it currently carries instead of pinning one.
- `-f` on both downloads, so a dead URL is an error rather than a file full of HTTP error text.
- `|| exit 1` on both downloads, so the build stops at the cause instead of cascading and then reporting success.

Bumping the pin to `3.12.13` would fix today's build and break again on the next upstream patch bump, so I left the pin out entirely.

`appimagetool`'s `continuous` URL still resolves, so that one is unchanged apart from the error handling. `AppRun`'s `opt/python3.12/` path is series-level, not patch-level, so it needs no change.

## Verification

Built on Ubuntu 24.04 to match the runner image.

Unpatched, the failure reproduces exactly as in CI: `python.AppImage` is 9 bytes containing `Not Found`, the first error is the `Not: command not found` above, no `dist/` is produced, and the script exits 0.

Patched:

- build completes and writes `dist/OnTheSpot-x86_64.AppImage`, 124 MB, carrying the type 2 magic
- bundled interpreter reports Python 3.12.13
- the AppImage extracts cleanly and round-trips
- `desktop-file-validate` passes on the `.desktop` entry
- `ffmpeg` and `ffplay` are bundled

The produced AppImage also launches, both self-mounted and extracted:

```
OnTheSpot Version: v1.1.4
Initialising main window, logging session : 3864405a-...
Main window init completed !
Accounts table was populated !
```

Failure paths, with the asset moved again:

- release carries no matching asset: exits 1 with `Could not find a cp312 manylinux2014 x86_64 asset on the python3.12 release`
- download 404s: exits 1, no cascade, no half-written `python.AppImage`

## One thing worth deciding

The release lookup is an unauthenticated `api.github.com` call, so it is subject to the 60 requests/hour per-IP limit. Release builds are infrequent enough that this should not bite, and if it ever does the guard exits 1 with a clear message rather than corrupting the build. If you would rather not depend on that at all, passing `GITHUB_TOKEN` through to the script and adding an `Authorization` header would remove the limit. Happy to add it if you want it.
