### PR TITLE
fix(bandcamp): search through the public search api

### DIFF
--- a/src/onthespot/api/bandcamp.py
+++ b/src/onthespot/api/bandcamp.py
@@ -8,6 +8,11 @@ from ..utils import conv_list_format, make_call
 
 logger = get_logger("api.bandcamp")
 
+# bandcamp.com/search is served behind a bot challenge and no longer returns
+# result markup, so use the endpoint the site's own search box calls.
+SEARCH_URL = 'https://bandcamp.com/api/bcsearch_public_api/1/autocomplete_elastic'
+SEARCH_FILTERS = {'track': 't', 'album': 'a', 'artist': 'b'}
+
 
 def bandcamp_login_user(account):
     logger.info('Logging into Bandcamp account...')
@@ -51,44 +56,38 @@ def bandcamp_add_account():
 
 def bandcamp_get_search_results(_, search_term, content_types):
     search_results = []
-    urls = []
-    if 'track' in content_types:
-        urls.append(f'https://bandcamp.com/search?q={search_term}&item_type=t')
-    if 'album' in content_types:
-        urls.append(f'https://bandcamp.com/search?q={search_term}&item_type=a')
-    if 'artist' in content_types:
-        urls.append(f'https://bandcamp.com/search?q={search_term}&item_type=b')
 
-    result_pattern = r'<li class="searchresult data-search"[^>]*>.*?</li>'
-    artwork_pattern = r'<a class="artcont" href=".*?">\s*<div class="art">\s*<img src="(?P<artwork_url>.*?)"\s*.*?>'
-    item_type_pattern = r'<div class="itemtype">\s*(?P<item_type>.*?)\s*</div>'
-    heading_pattern = r'<div class="heading">\s*<a href="(?P<url>.*?)".*?>(?P<title>.*?)</a>'
+    for item_type, search_filter in SEARCH_FILTERS.items():
+        if item_type not in content_types:
+            continue
 
-    for url in urls:
-        data = make_call(url, skip_cache=True, text=True, use_ssl=True)
+        response = requests.post(SEARCH_URL, json={
+            'search_text': search_term,
+            'search_filter': search_filter,
+            'full_page': False,
+            'fan_id': None
+        })
 
-        results = re.findall(result_pattern, data, re.DOTALL)
-        for result in results:
-            artwork_match = re.search(artwork_pattern, result, re.DOTALL)
-            artwork_url = artwork_match.group('artwork_url') if artwork_match else None
+        if response.status_code != 200:
+            logger.info(f"Request status error {response.status_code}: {SEARCH_URL}")
+            continue
 
-            item_type_match = re.search(item_type_pattern, result, re.DOTALL)
-            item_type = item_type_match.group('item_type').strip().lower() if item_type_match else None
+        results = response.json().get('auto', {}).get('results', [])
+        for result in results[:config.get("max_search_results")]:
+            # Artists carry no item_url_path; their root url is the artist page.
+            url = result.get('item_url_path') or result.get('item_url_root')
+            if not url:
+                continue
 
-            heading_match = re.search(heading_pattern, result, re.DOTALL)
-            url = heading_match.group('url') if heading_match else None
-            title = heading_match.group('title').strip() if heading_match else None
-
-            if artwork_url and item_type and url and title:
-                search_results.append({
-                    'item_id': url.split('?')[0],
-                    'item_name': title,
-                    'item_by': None,
-                    'item_type': item_type,
-                    'item_service': "bandcamp",
-                    'item_url': url.split('?')[0], # Clean url
-                    'item_thumbnail_url': artwork_url
-                })
+            search_results.append({
+                'item_id': url,
+                'item_name': result.get('name'),
+                'item_by': result.get('band_name'),
+                'item_type': item_type,
+                'item_service': "bandcamp",
+                'item_url': url,
+                'item_thumbnail_url': result.get('img')
+            })
 
     return search_results
 


### PR DESCRIPTION
Fixes #302.

The traceback in that report (`bandcamp_get_search_results() takes 3 positional arguments but 7 were given`) was a separate arity bug, already fixed in #315. Bandcamp search is still broken, for a different reason.

## Cause

`bandcamp.com/search` is now served behind a bot challenge. It returns roughly 3 KB titled `Client Challenge` instead of result markup, so `result_pattern` matches nothing and every search returns an empty list. The string `searchresult` does not appear in the response at all:

```
>>> r = requests.get('https://bandcamp.com/search?q=aphex+twin&item_type=a')
>>> r.status_code, len(r.text)
(200, 3036)
>>> 'Client Challenge' in r.text, r.text.count('searchresult')
(True, 0)
```

Note the 200 — the challenge is not an error status, so nothing downstream notices.

It is not user-agent or cookie dependent. All three of these get the same challenge page:

| attempt | bytes | challenge | results matched |
|---|---|---|---|
| `session.get(url)`, no headers (what `make_call` does) | 3036 | yes | 0 |
| with a Chrome user agent | 3036 | yes | 0 |
| after `session.get('https://bandcamp.com')` first, to pick up cookies | 3036 | yes | 0 |

So no amount of regex work brings this back. The markup is not being served.

## Change

Use the endpoint Bandcamp's own search box calls, `bcsearch_public_api/1/autocomplete_elastic`. It returns JSON, is not challenged, and carries the fields the scraper was reconstructing out of HTML. `search_filter` takes `t`/`a`/`b`, which lines up with the existing `content_types`.

Two behaviour changes worth calling out:

- **Artists have no `item_url_path`**, so those fall back to `item_url_root`. That is the bare artist page url, which is the form `parse_url` already classifies as `artist`.
- **`item_by` is now populated** from `band_name`. The scraper had no way to reach the artist name and hardcoded `None`.

I also sliced the results to `max_search_results`, matching `apple_music`, `crunchyroll`, `deezer`, `qobuz` and `soundcloud`. The scraper ignored that setting and returned a whole page; the api returns 50 per type against a default of 10. Happy to drop this part if you would rather keep it as a separate change.

`requests` was already imported and used directly in this module, and `soundcloud.py` calls `requests` per content type rather than going through `make_call`, so this follows the existing shape. `make_call` is untouched and the album and track scrapers still use it — those pages are not challenged.

## Verification

Ran against live Bandcamp on Ubuntu 24.04, using the interpreter from an AppImage build so the dependency versions match a real install. Same script against this branch and against `master`:

| | master | this branch |
|---|---|---|
| `bandcamp_get_search_results(None, 'aphex twin', ['track','album','artist'])` | 0 results | 22 results |
| via `search.get_search_results(...)`, the path in the #302 traceback | 0 results | 22 results |

Contract checks on the 22, all passing: the returned dicts have exactly the same key set as before, every `item_url` matches `BANDCAMP_URL_REGEX` in `parse_item.py`, no result carries an unexpected `item_type`, none is missing a required field, none exceeds `max_search_results` per type, `item_service` is always `bandcamp`, and `item_id == item_url` with no duplicates.

Edge cases, all passing: requesting only `album` returns only albums; requesting only `artist` returns bare artist roots with no `/track/` or `/album/` paths; an empty `content_types` issues no requests and returns `[]`; a nonsense query returns `[]` without raising; a unicode query (`坂本龍一`) and one with punctuation both work.

Results also route through the rest of the pipeline. Feeding one of each type into `parse_url` with the `parsingworker` thread running:

```
staged track  https://aphextwin.bandcamp.com/track/windowlicker
staged album  https://aphextwin.bandcamp.com/album/drukqs
staged artist https://aphextwin.bandcamp.com
parsing left: 0  pending: 31
services: {'bandcamp'}
types: {'track': 31}
```

The album expanded to its tracks and the artist expanded through its albums to tracks, so search results are queueable, not just displayable.

## One caveat

I can only test from one location. If the challenge turns out to be IP or region dependent, you may still get real HTML from `bandcamp.com/search` and be unable to reproduce the original bug. The change is still correct either way — the API path is not challenged anywhere — but I wanted to flag it rather than have you chase a repro that will not happen on your connection.
