### PR TITLE
fix: three download failures (SoundCloud metadata, encoding, YouTube formats)

### DIFF
--- a/src/onthespot/api/soundcloud.py
+++ b/src/onthespot/api/soundcloud.py
@@ -347,7 +347,11 @@ def soundcloud_get_track_metadata(token, item_id):
     info['track_number'] = track_number
     info['total_tracks'] = total_tracks
     #info['file_url'] = track_file.get("url")
-    info['length'] = str(track_data.get("media", {}).get("transcodings", [{}])[0].get("duration", 0))
+    # The [{}] default only applies when the key is missing; SoundCloud often
+    # returns an empty list, so fall back to the track's own duration.
+    transcodings = track_data.get("media", {}).get("transcodings") or []
+    info['length'] = str(transcodings[0].get("duration", 0) if transcodings
+                         else track_data.get("duration", 0))
     info['artists'] = artists
     info['album_name'] = album_name
     info['album_type'] = album_type

--- a/src/onthespot/downloader.py
+++ b/src/onthespot/downloader.py
@@ -417,7 +417,7 @@ class DownloadWorker(QObject):
                         elif item_service == "youtube_music":
                             default_format = '.m4a'
                             bitrate = "128k"
-                            ydl_opts['format'] = 'bestaudio[ext=m4a]'
+                            ydl_opts['format'] = 'bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio'
                         ydl_opts['quiet'] = True
                         ydl_opts['no_warnings'] = True
                         ydl_opts['noprogress'] = True

--- a/src/onthespot/utils.py
+++ b/src/onthespot/utils.py
@@ -57,6 +57,11 @@ def make_call(url, params=None, headers=None, session=None, skip_cache=False, te
     response = session.get(url, headers=headers, params=params)
 
     if response.status_code == 200:
+        # SoundCloud serves 'Content-Type: text/html' with no charset, so
+        # requests falls back to ISO-8859-1 and mangles non-Latin text.
+        # Trust the body's own encoding instead.
+        if response.encoding is None or response.encoding.lower() in ('iso-8859-1', 'latin-1'):
+            response.encoding = response.apparent_encoding or 'utf-8'
         if not skip_cache:
             with open(req_cache_file, 'w', encoding='utf-8') as cf:
                 cf.write(response.text)


### PR DESCRIPTION
While working with Claude Code on my own music library I went looking for why none of my files had metadata, and fell down a rabbit hole into three separate bugs. Sharing the fixes back.

Three independent bugs, each blocking a distinct set of downloads. Found while debugging a library where 0 of 92 files had usable metadata.

### 1. `IndexError` on empty `transcodings` — `api/soundcloud.py`

The `[{}]` default only applies when the key is *absent*. SoundCloud frequently returns `"transcodings": []`, so `[0]` raises `IndexError` and aborts the whole metadata fetch — over the cosmetic `length` field. Failed 14 of 16 tracks in one sample here.

```
File "onthespot/api/soundcloud.py", line 350, in soundcloud_get_track_metadata
    track_data.get("media", {}).get("transcodings", [{}])[0].get("duration", 0)
IndexError: list index out of range
```

### 2. Mojibake on non-Latin metadata — `utils.py`

SoundCloud serves `Content-Type: text/html` with no charset. Per RFC 2616 requests falls back to ISO-8859-1, so `response.text` mangles non-Latin text. Album names scraped from the HTML came through broken while titles read from JSON stayed correct:

```
album (scraped HTML): ×××× ××× - ×××¨ ××¢××¨
title (from JSON):    גידי גוב - שיר העבודה
```

The guard only fires for charset-less `text/*` responses; `application/json` already resolves to utf-8, so no JSON request pays for charset detection.

### 3. No format fallback for YouTube Music — `downloader.py`

`bestaudio[ext=m4a]` has no fallback, so a track with no m4a audio-only stream fails with `Requested format is not available`. Uses the same fallback chain the SoundCloud branch already has.

---

Verified against a live 136-track library: bug 1 went from 14 failures to 0, bug 2's mojibake to 0, and YouTube downloads to 50/50.
