### PR TITLE
Fix encoded Apple Music playlist URLs

### DIFF
--- a/api/src/onthespot/resources/regexes.py
+++ b/api/src/onthespot/resources/regexes.py
@@ -6,7 +6,7 @@ import re
 # Audio services
 APPLE_MUSIC_URL_REGEX = re.compile(
     r"https?://music.apple.com/([a-z]{2})/(?P<type>album|playlist|artist)"
-    r"(?:/(?P<title>[-a-z0-9]+))?/(?P<id>[\w.-]+)"
+    r"(?:/(?P<title>[^/]+))?/(?P<id>[\w.-]+)"
     r"(?:\?i=(?P<track_id>\d+))?(?:&.*)?$"
 )
 BANDCAMP_URL_REGEX = re.compile(

--- a/api/tests/test_url_regexes.py
+++ b/api/tests/test_url_regexes.py
@@ -1,0 +1,20 @@
+import unittest
+
+from _support import TEST_ROOT  # noqa: F401
+
+from onthespot.resources.regexes import APPLE_MUSIC_URL_REGEX  # noqa: E402
+
+
+class AppleMusicUrlRegexTests(unittest.TestCase):
+    def test_percent_encoded_playlist_slug(self):
+        match = APPLE_MUSIC_URL_REGEX.search(
+            "https://music.apple.com/ru/playlist/%D0%BF%D0%B5%D1%81%D0%BD%D0%B8/pl.a3f7a612412545759582b0c9ac082a0d"
+        )
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group("type"), "playlist")
+        self.assertEqual(match.group("id"), "pl.a3f7a612412545759582b0c9ac082a0d")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- accept percent-encoded and non-ASCII Apple Music URL slugs
- add a regression test for encoded playlist URLs

## Test
- `PYTHONPATH=api/src:api/tests api/.venv/bin/python -m unittest api.tests.test_url_regexes`